### PR TITLE
Do not force push under any circumstance

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,12 +61,6 @@ func Execute() {
 func init() {
 	// Call initConfig() for every command before running
 	cobra.OnInitialize(initConfig)
-	log.Logger = log.With().Str("version", util.Version()).Logger()
-
-	if zerolog.Nop().GetLevel() == zerolog.TraceLevel {
-		log.Logger = log.With().Caller().Str("version", util.Version()).Logger()
-	}
-
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
@@ -88,5 +82,11 @@ func initConfig() {
 	if textLogs {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
+	log.Logger = log.With().Str("version", util.Version()).Logger()
+
+	if zerolog.Nop().GetLevel() == zerolog.TraceLevel {
+		log.Logger = log.With().Caller().Logger()
+	}
+
 	config.LoadConfig(cfgFile)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.3.0
 	github.com/go-redis/redis/v8 v8.7.1
-	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-github/v35 v35.2.0
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/mux v1.7.4
 	github.com/magiconair/properties v1.8.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,9 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v35 v35.2.0 h1:s/soW8jauhjUC3rh8JI0FePuocj0DEI9DNBg/bVplE8=
+github.com/google/go-github/v35 v35.2.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/policy/action-templates/sync-automation.tmpl
+++ b/policy/action-templates/sync-automation.tmpl
@@ -3,7 +3,7 @@
 
 # This workflow should only exist in {{ .SrcBranch }}
 # Missing files are silently ignored. Most of the time this is what we want, older repos may not have some files
-# If {{ .DestBranch }} does not exist, it will be created
+# If fwd or backport branches do not exist, they will be created
 
 name: Sync automation
 
@@ -15,22 +15,53 @@ on:
     {{- end }}
 
 jobs:
-  sync:
+{{ if .Backport }}
+  backport:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
         with:
-          depth: 1
+          fetch-depth: 1
 
-      - name: sync {{ .SrcBranch }} → {{ .DestBranch }}
+      - name: Backport {{ .SrcBranch }} → {{ .Backport }}
         run: |
-          git fetch origin +refs/heads/{{ .DestBranch }}:refs/heads/{{ .DestBranch }} && git checkout {{ .DestBranch }}
+          git checkout {{ .Backport }} || git checkout -b {{ .Backport }}
           git config --local user.email "policy@gromit"
           git config --local user.name "Bender"
           {{- range $file := .MAFiles }}
           git checkout --theirs origin/{{ $.SrcBranch }} -- {{ $file }}
 	  {{- end }}
           git commit -m "[CI] Backport release automation from {{ .SrcBranch }}" -m "{{ `${{ github.event.head_commit.message }}` }}"
-          git push origin {{ .DestBranch }}
-          echo "::debug::syncd from {{ .SrcBranch }} to {{ .DestBranch }}"
+          git push -u origin {{ .Backport }}
+          echo "::debug::syncd from {{ .SrcBranch }} to {{ .Backport }}"
+{{ end }}
+
+{{ if .Fwdports }}
+  fwdport:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: {{range $fp := .Fwdports }}
+          - {{ $fp }}
+	{{- end }}
+          
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: {{ `${{matrix.branch}}` }}
+
+      - name: Forward port {{ .SrcBranch }} → {{ `${{matrix.branch}}` }}
+        run: |
+          git checkout {{ `${{matrix.branch}}` }} || git checkout -b {{ `${{matrix.branch}}` }}
+          git config --local user.email "policy@gromit"
+          git config --local user.name "Bender"
+          {{- range $file := .MAFiles }}
+          git checkout --theirs origin/{{ $.SrcBranch }} -- {{ $file }}
+	  {{- end }}
+          git commit -m "[CI] Fwdport release automation from {{ .SrcBranch }}" -m "{{ `${{ github.event.head_commit.message }}` }}"
+          git push -u origin {{ `${{matrix.branch}}` }}
+          echo "::debug::syncd from {{ .SrcBranch }} to {{ `${{matrix.branch}}` }}"
+{{ end }}

--- a/policy/branch.go
+++ b/policy/branch.go
@@ -3,11 +3,11 @@ package policy
 import "errors"
 
 type branchPolicies struct {
-	Protected    []string            `mapstructure:",omitempty"`
 	Deprecations map[string][]string `mapstructure:",omitempty"`
 	Backports    map[string]string   `mapstructure:",omitempty"`
 	Fwdports     map[string][]string `mapstructure:",omitempty"`
 	Files        []string            `mapstructure:",omitempty"`
+	Protected    []string            `mapstructure:",omitempty"`
 }
 
 var ErrUnknownBranch = errors.New("branch not present in branch policies of repo")

--- a/policy/branch.go
+++ b/policy/branch.go
@@ -1,21 +1,25 @@
 package policy
 
-import (
-	"fmt"
-)
+import "errors"
 
 type branchPolicies struct {
 	Protected    []string            `mapstructure:",omitempty"`
 	Deprecations map[string][]string `mapstructure:",omitempty"`
 	Backports    map[string]string   `mapstructure:",omitempty"`
+	Fwdports     map[string][]string `mapstructure:",omitempty"`
 	Files        []string            `mapstructure:",omitempty"`
 }
+
+var ErrUnknownBranch = errors.New("branch not present in branch policies of repo")
 
 // (bp branchPolicies) SrcBranches returns the list of branches for which automatic backport sync is implemented
 // i.e. commits landing on these branches will be sync'd to the backport branch
 func (bp branchPolicies) SrcBranches() []string {
 	keys := make([]string, 0, len(bp.Backports))
 	for k := range bp.Backports {
+		keys = append(keys, k)
+	}
+	for k := range bp.Fwdports {
 		keys = append(keys, k)
 	}
 	return keys
@@ -25,7 +29,16 @@ func (bp branchPolicies) SrcBranches() []string {
 func (bp branchPolicies) BackportBranch(srcBranch string) (string, error) {
 	destBranch, found := bp.Backports[srcBranch]
 	if !found {
-		return "", fmt.Errorf("branch %s unknown among %v", srcBranch, bp.Backports)
+		return "", ErrUnknownBranch
 	}
 	return destBranch, nil
+}
+
+// (bp branchPolicies) FwdportBranch returns the branches to which commits from srcBranch should be sync'd to
+func (bp branchPolicies) FwdportBranch(srcBranch string) ([]string, error) {
+	destBranches, found := bp.Fwdports[srcBranch]
+	if !found {
+		return []string{}, ErrUnknownBranch
+	}
+	return destBranches, nil
 }

--- a/policy/doctor.go
+++ b/policy/doctor.go
@@ -55,7 +55,7 @@ func (r *GitRepo) CheckMetaAutomation(rp RepoPolicies) error {
 	}
 	log.Debug().Bool("exists", exists).Bool("shouldExist", shouldExist).Msg("current vs desired")
 	var remoteBranch string
-	isProtected, err := rp.IsProtected(r.Name, r.branch)
+	isProtected, err := r.IsProtected(r.branch)
 	if err != nil {
 		return fmt.Errorf("getting protected status: %w", err)
 	}
@@ -128,8 +128,9 @@ func (r *GitRepo) AddMetaAutomation(commitMsg string, rp RepoPolicies) error {
 	}
 	log.Trace().Interface("tv", tv).Msg("template vars for adding meta automation")
 	err = t.Execute(op, tv)
-	hash, err := r.addFile(opFile, commitMsg, true)
-
-	log.Debug().Str("hash", hash.String()).Str("path", opFile).Msg("sync-automation.yml generated")
+	if err != nil {
+		return fmt.Errorf("rendering template: %w", err)
+	}
+	_, err = r.addFile(opFile, commitMsg, true)
 	return err
 }

--- a/policy/git.go
+++ b/policy/git.go
@@ -19,7 +19,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/go-git/go-git/v5/storage/memory"
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/oauth2"
@@ -124,7 +124,7 @@ func (r *GitRepo) addFile(path, msg string, confirm bool) (plumbing.Hash, error)
 	log.Trace().Str("hash", origHead.String()).Msg("HEAD")
 	hash, err := r.worktree.Add(path)
 	if err != nil {
-		return plumbing.ZeroHash, fmt.Errorf("adding to worktree: %w", err)
+		return plumbing.ZeroHash, fmt.Errorf("adding %s to worktree: %w", path, err)
 	}
 	log.Trace().Str("hash", hash.String()).Msg("add")
 	newCommitHash, err := r.worktree.Commit(msg, r.commitOpts)
@@ -147,7 +147,7 @@ func (r *GitRepo) addFile(path, msg string, confirm bool) (plumbing.Hash, error)
 		return plumbing.ZeroHash, fmt.Errorf("encoding diff: %w", err)
 	}
 	if confirm {
-		fmt.Printf("\n----End of diff for %s. Control-C to abort, ⏎/Enter to continue.", r.Name)
+		fmt.Printf("\n----End of diff for branch %s on %s. Control-C to abort, ⏎/Enter to continue.", r.branch, r.Name)
 		fmt.Scanln()
 	}
 

--- a/policy/github.go
+++ b/policy/github.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/rs/zerolog/log"
 )
 
@@ -15,6 +15,16 @@ const ghOrg = "TykTechnologies"
 
 //go:embed pr-templates
 var ghTemplates embed.FS
+
+// (rp RepoPolicies) IsProtected tells you if a branch can be pushed directly to origin or needs to go via a PR
+func (r *GitRepo) IsProtected(branch string) (bool, error) {
+	b, resp, err := r.gh.Repositories.GetBranch(context.Background(), ghOrg, r.Name, branch)
+	if err != nil {
+		return true, fmt.Errorf("error: %w, response: %v", err, resp)
+	}
+
+	return b.GetProtected(), nil
+}
 
 func (r *GitRepo) CreatePR(title, templateName string, rp RepoPolicies, removal bool) error {
 	if r.branch == "" {

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -64,10 +64,9 @@ func TestPortsPolicy(t *testing.T) {
 	}{
 		{
 			cfgFile:     "../testdata/policies/gateway.yaml",
-			protBranch:  "release-3-lts",
 			testBranch:  "release-3.0.5",
 			name:        "tyk",
-			srcBranches: []string{"release-3.2.0", "release-3.0.5", "release-3.1.2"},
+			srcBranches: []string{"release-3.2.0", "release-3.0.5", "release-3.1.2", "master"},
 			prVars: prVars{
 				RepoName: "tyk",
 				Files:    gatewayFiles,
@@ -80,15 +79,15 @@ func TestPortsPolicy(t *testing.T) {
 				Remove: false,
 			},
 			maVars: maVars{
-				Timestamp:  timeStamp,
-				MAFiles:    gatewayFiles,
-				SrcBranch:  "release-3.0.5",
-				DestBranch: "releng/release-3-lts",
+				Timestamp: timeStamp,
+				MAFiles:   gatewayFiles,
+				SrcBranch: "release-3.0.5",
+				Backport:  "releng/release-3-lts",
+				Fwdports:  []string{"release-3.2", "release-3.2.0"},
 			},
 		},
 		{
 			cfgFile:     "../testdata/policies/dashboard.yaml",
-			protBranch:  "master",
 			testBranch:  "release-3.0.5",
 			name:        "tyk-analytics",
 			srcBranches: []string{"release-3.1.2", "release-3.0.5"},
@@ -103,15 +102,15 @@ func TestPortsPolicy(t *testing.T) {
 				Remove: false,
 			},
 			maVars: maVars{
-				Timestamp:  timeStamp,
-				MAFiles:    dashboardFiles,
-				SrcBranch:  "release-3.0.5",
-				DestBranch: "releng/release-3-lts",
+				Timestamp: timeStamp,
+				MAFiles:   dashboardFiles,
+				SrcBranch: "release-3.0.5",
+				Backport:  "releng/release-3-lts",
+				Fwdports:  []string{"release-3.2", "release-3.2.0"},
 			},
 		},
 		{
 			cfgFile:    "../testdata/policies/pump.yaml",
-			protBranch: "master",
 			name:       "tyk-pump",
 			testBranch: "release-1.3",
 			prVars: prVars{
@@ -127,7 +126,6 @@ func TestPortsPolicy(t *testing.T) {
 		},
 		{
 			cfgFile:     "../testdata/policies/mdcb.yaml",
-			protBranch:  "master",
 			testBranch:  "release-1.8",
 			name:        "tyk-sink",
 			srcBranches: []string{"release-1.9", "release-1.8", "release-1.7"},
@@ -143,10 +141,10 @@ func TestPortsPolicy(t *testing.T) {
 				Remove: false,
 			},
 			maVars: maVars{
-				Timestamp:  timeStamp,
-				MAFiles:    baseFiles,
-				SrcBranch:  "release-1.8",
-				DestBranch: "releng/master",
+				Timestamp: timeStamp,
+				MAFiles:   baseFiles,
+				SrcBranch: "release-1.8",
+				Backport:  "releng/master",
 			},
 		},
 	}
@@ -158,11 +156,6 @@ func TestPortsPolicy(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Could not load policy for %s: %v", tc.name, err)
 			}
-			isProtected, err := rp.IsProtected(tc.name, tc.protBranch)
-			if err != nil {
-				t.Errorf("Failed to get protected status for %s: %w", tc.protBranch, err)
-			}
-			assert.Equal(t, true, isProtected)
 			srcBranches, err := rp.SrcBranches(tc.name)
 			if err != nil {
 				t.Errorf("Failed to get source branches for %s: %w", tc.protBranch, err)

--- a/testdata/policies/dashboard.yaml
+++ b/testdata/policies/dashboard.yaml
@@ -1,3 +1,6 @@
+loglevel: debug
+textlogs: true
+
 policy:
   protected: [ master ]
   files:
@@ -21,6 +24,8 @@ policy:
         v3.0.1:
           - .github/workflows/int-image.yml
           - bin/integration_build.sh
+      fwdports:
+        master: [ release-3.2, release-3.2.0 ]
       backports:
         release-3.0.5: releng/release-3-lts
         release-3.1.2: releng/release-3.1

--- a/testdata/policies/gateway.yaml
+++ b/testdata/policies/gateway.yaml
@@ -1,5 +1,7 @@
+loglevel: trace
+textlogs: true
+
 policy:
-  protected: [ master ]
   files:
     - bin/unlock-agent.sh
     - .goreleaser.yml
@@ -14,13 +16,14 @@ policy:
     - install/post_remove.sh
   repos:
     tyk:
-      protected: [ release-3-lts ]
       files:
         - images/*
       deprecations:
         v3.0.1:
           - .github/workflows/int-image.yml
           - bin/integration_build.sh
+      fwdports:
+        master: [ release-3.2, release-3.2.0 ]
       backports:
         release-3.0.5: releng/release-3-lts
         release-3.1.2: releng/release-3.1


### PR DESCRIPTION
Apparently, if you fill in [PushOptions](https://pkg.go.dev/github.com/go-git/go-git/v5#PushOptions).RefSpecs it _will_ force push if necessary. Instead we now save the HEAD ref before we start and use PushOptions.RequireRemoteRefs for extra safety.

This was the cause of much heartburn over the weekend and I'd appreciate a review of what I'm doing. For more context on what's going on here https://headroom.tyk.technology/video/512/managing-release-policy