### PR TITLE
Update dependabot template for pump.

### DIFF
--- a/policy/templates/releng/.github/dependabot.yml
+++ b/policy/templates/releng/.github/dependabot.yml
@@ -9,3 +9,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+{{ if eq .Name "tyk-pump" }}
+  - package-ecosystem: "gomod"
+    # Look for `go.mod` file in the `root` directory
+    directory: "/"
+    # Check the gomod registry for updates every Monday
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "platform"
+    # max number of pull requests that dependabot will open in tandem
+    open-pull-requests-limit: 4
+{{- end }}


### PR DESCRIPTION
Pump has a dependabot PR flow configured for go.mod update. This PR updates the corresponding releng templates  so that it's persisted across further renders of the template.