### PR TITLE
Fix the nfpm contents path for portal.

### DIFF
--- a/policy/templates/releng/ci/goreleaser/goreleaser-el7.yml.d/nfpm.tmpl
+++ b/policy/templates/releng/ci/goreleaser/goreleaser-el7.yml.d/nfpm.tmpl
@@ -86,12 +86,12 @@ nfpms:
       - src: portal.conf
         dst: /opt/{{ .PackageName }}/{{ .Branchvals.ConfigFile }}
         type: "config|noreplace"
-      - src: app/*
-        dst: /opt/{{ .PackageName }}/app/
-      - src: themes/*
-        dst: /opt/{{ .PackageName }}/themes/
-      - src: public/system/*
-        dst: /opt/{{ .PackageName }}/public/system/
+      - src: app
+        dst: /opt/{{ .PackageName }}/app
+      - src: themes
+        dst: /opt/{{ .PackageName }}/themes
+      - src: public/system
+        dst: /opt/{{ .PackageName }}/public/system
       - src: ci/entrypoint.sh
         dst: /opt/{{ .PackageName }}/entrypoint.sh
         file_info:

--- a/policy/templates/releng/ci/goreleaser/goreleaser.yml.d/nfpm.tmpl
+++ b/policy/templates/releng/ci/goreleaser/goreleaser.yml.d/nfpm.tmpl
@@ -90,12 +90,12 @@ nfpms:
       - src: portal.conf
         dst: /opt/{{ .PackageName }}/{{ .Branchvals.ConfigFile }}
         type: "config|noreplace"
-      - src: app/*
-        dst: /opt/{{ .PackageName }}/app/
-      - src: themes/*
-        dst: /opt/{{ .PackageName }}/themes/
-      - src: public/system/*
-        dst: /opt/{{ .PackageName }}/public/system/
+      - src: app
+        dst: /opt/{{ .PackageName }}/app
+      - src: themes
+        dst: /opt/{{ .PackageName }}/themes
+      - src: public/system
+        dst: /opt/{{ .PackageName }}/public/system
       - src: ci/entrypoint.sh
         dst: /opt/{{ .PackageName }}/entrypoint.sh
         file_info:


### PR DESCRIPTION
Portal has a bunch of directories which it depends on for proper installation and running.
The nfpm path was set mistakenly before which led to not having the entire directory tree present. 
This PR fixes this issue.