### PR TITLE
Fix some invalid paths in sync-automation.

### DIFF
--- a/policy/templates/sync/.github/workflows/sync-automation.yml
+++ b/policy/templates/sync/.github/workflows/sync-automation.yml
@@ -2,10 +2,18 @@
 # Generated on: {{ .Timestamp }}
 
 {{- $dirs := list "ci" }}
-{{- $files := list ".github/workflows/api-tests.yml" ".github/workflows/release.yml" ".github/dependabot.yml" }}
+{{- $files := list ".github/workflows/release.yml" ".github/dependabot.yml" }}
 
-{{- if eq .Name "tyk-analytics" }}
-  {{- $files = list ".github/workflows/api-tests.yml" ".github/workflows/release.yml" ".github/dependabot.yml" ".github/workflows/ui-tests.yml" }}
+{{- if or (eq .Name "tyk-analytics") }}
+  {{- $files = append $files ".github/workflows/api-tests.yml" ".github/workflows/ui-tests.yml" }}
+{{- end }}
+
+{{- if or (eq .Name "tyk") }}
+  {{- $files = append $files ".github/workflows/api-tests.yml" }}
+{{- end }}
+
+{{- if or (eq .Name "portal") }}
+  {{- $files = append $files ".github/workflows/api_tests.yml" ".github/workflows/ui-tests.yml"}}
 {{- end }}
 
 name: Sync automation

--- a/testdata/sync-automation/sync-automation.yml
+++ b/testdata/sync-automation/sync-automation.yml
@@ -9,9 +9,9 @@ on:
       - master
     paths:
       - ci/**
-      - .github/workflows/api-tests.yml
       - .github/workflows/release.yml
       - .github/dependabot.yml
+      - .github/workflows/api-tests.yml
 
 jobs:
   sync:
@@ -41,12 +41,12 @@ jobs:
           git checkout -b $prbranch
           rm -rf ci
           git restore --source master -- ci
-          rm -f .github/workflows/api-tests.yml
-          git restore --source master -- .github/workflows/api-tests.yml
           rm -f .github/workflows/release.yml
           git restore --source master -- .github/workflows/release.yml
           rm -f .github/dependabot.yml
           git restore --source master -- .github/dependabot.yml
+          rm -f .github/workflows/api-tests.yml
+          git restore --source master -- .github/workflows/api-tests.yml
           git add -A && git commit -m "[CI]: Syncing CI changes to ${{ matrix.branch }}"
           git push origin $prbranch
           echo "::set-output name=prbranch::$prbranch"


### PR DESCRIPTION
API tests are not available in all repos. Also the file names change across repos for api tests. Try to handle this for the repos under management.

example of failed sync here: https://github.com/TykTechnologies/tyk-identity-broker/actions/runs/3061029819/jobs/4940284159#step:3:53