### PR TITLE
[TD-1168]: Add reviewers to gromit policy.

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -39,6 +39,7 @@ type Policies struct {
 	DHRepo      string
 	CSRepo      string
 	PackageName string
+	Reviewers   []string
 	ExposePorts string
 	Binary      string
 	Protected   []string
@@ -60,6 +61,7 @@ type RepoPolicy struct {
 	CSRepo      string
 	Binary      string
 	PackageName string
+	Reviewers   []string
 	ExposePorts string
 	Files       map[string][]string
 	Ports       map[string][]string
@@ -91,6 +93,7 @@ func (p *Policies) GetRepo(repo, prefix, branch string) (RepoPolicy, error) {
 		Branch:      branch,
 		prefix:      prefix,
 		Branchvals:  b,
+		Reviewers:   r.Reviewers,
 		DHRepo:      r.DHRepo,
 		PCRepo:      r.PCRepo,
 		CSRepo:      r.CSRepo,

--- a/policy/templates/releng/.github/dependabot.yml
+++ b/policy/templates/releng/.github/dependabot.yml
@@ -18,8 +18,12 @@ updates:
     # Check the gomod registry for updates every Monday
     schedule:
       interval: "weekly"
+  {{- if .Reviewers }}
     reviewers:
-      - "TykTechnologies/platform"
+    {{- range .Reviewers }}
+      - "{{ . }}"
+    {{- end }}
+  {{- end }}
     # max number of pull requests that dependabot will open in tandem
     open-pull-requests-limit: 4
 {{- end }}

--- a/testdata/policies/repos.yaml
+++ b/testdata/policies/repos.yaml
@@ -8,6 +8,7 @@ policy:
       pcrepo: tyk-gateway
       dhrepo: tykio/tyk-gateway
       csrepo: docker.tyk.io/tyk-gateway/tyk-gateway
+      reviewers: []
       packagename: tyk-gateway
       binary: tyk
       protected: [ release-3-lts, release-4 ]
@@ -38,6 +39,7 @@ policy:
       csrepo: docker.tyk.io/tyk-dashboard/tyk-dashboard
       exposeports: "3000 5000"
       binary: tyk-analytics
+      reviewers: []
       packagename: tyk-dashboard
       protected: [ release-3-lts, release-4, release-4-lts ]
       branches:
@@ -56,6 +58,7 @@ policy:
       pcrepo: tyk-pump
       dhrepo: tykio/tyk-pump-docker-pub
       csrepo: docker.tyk.io/tyk-pump/tyk-pump
+      reviewers: [ TykTechnologies/platform-squad ]
       exposeports: "80"
       binary: tyk-pump
       packagename: tyk-pump
@@ -77,6 +80,7 @@ policy:
       csrepo: docker.tyk.io/tyk-identity-broker/tyk-identity-broker
       exposeports: 80
       binary: tyk-identity-broker
+      reviewers: []
       packagename: tyk-identity-broker
       protected: [ master, release-1.3, release-1.2 ]
       branches:
@@ -96,6 +100,7 @@ policy:
       csrepo: docker.tyk.io/tyk-sink/tyk-sink
       exposeports: 80
       binary: tyk-sink
+      reviewers: []
       packagename: tyk-sink
       protected: [ master, release-2, release-1.9 ]
       branches:
@@ -114,6 +119,7 @@ policy:
       dhrepo: tykio/portal
       csrepo: docker.tyk.io/portal/portal
       exposeports: 80
+      reviewers: []
       binary: dev-portal
       packagename: portal
       protected: [ master, release-1.0 ]

--- a/testdata/policies/repos.yaml
+++ b/testdata/policies/repos.yaml
@@ -80,7 +80,7 @@ policy:
       csrepo: docker.tyk.io/tyk-identity-broker/tyk-identity-broker
       exposeports: 80
       binary: tyk-identity-broker
-      reviewers: []
+      reviewers: [ TykTechnologies/platform-squad ]
       packagename: tyk-identity-broker
       protected: [ master, release-1.3, release-1.2 ]
       branches:
@@ -100,7 +100,7 @@ policy:
       csrepo: docker.tyk.io/tyk-sink/tyk-sink
       exposeports: 80
       binary: tyk-sink
-      reviewers: []
+      reviewers: [ TykTechnologies/platform-squad ]
       packagename: tyk-sink
       protected: [ master, release-2, release-1.9 ]
       branches:


### PR DESCRIPTION
For dependabot, and other auto generated PRs, it would be nice to have a list of reviewers who could be assigned to review these PRs once these are generated.
This PR adds the functionality to gromit. More details in [TD-1168]

[TD-1168]: https://tyktech.atlassian.net/browse/TD-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ