### PR TITLE
Remove commit message linter from required checks

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -136,7 +136,7 @@ policy:
           configfile: tyk_analytics.conf
           versionpackage: github.com/TykTechnologies/tyk-analytics/dashboard
           convos: false
-          tests: ["commit message linter", "test (1.16.x, ubuntu-latest, amd64, 15.x)", "sqlite", "ci", "mongo"]
+          tests: ["test (1.16.x, ubuntu-latest, amd64, 15.x)", "sqlite", "ci", "mongo"]
           reviewcount: 0
           branch:
             release-3-lts:


### PR DESCRIPTION
Release notes are now filled with JIRA, commit message linter is obsolete, removing.

https://tyktech.atlassian.net/browse/TT-7456

Blocking https://github.com/TykTechnologies/tyk-analytics/pull/2886