### PR TITLE
[TT-7642] Reduce CVE surface by removing cURL

### DIFF
--- a/policy/templates/releng/ci/Dockerfile.std
+++ b/policy/templates/releng/ci/Dockerfile.std
@@ -19,7 +19,7 @@ RUN apt-get install -y curl python3-setuptools libpython3.9 python3.9-dev \
 
 
 # Remove some things to decrease CVE surface
-RUN  apt-get remove -y --allow-remove-essential libtiff5 ncurses-base \
+RUN  apt-get remove -y --allow-remove-essential --auto-remove curl libtiff5 ncurses-base \
 	&& rm /usr/bin/passwd && rm /usr/sbin/adduser
 
 # Clean up caches, unwanted .a and .o files


### PR DESCRIPTION
Reduce Ensure that curl is removed when it no longer needed. At the moment it accounts for a few critical/high vurneabilities flagged by dockerhub.