### PR TITLE
upgrading go version in TIB

### DIFF
--- a/testdata/policies/repos.yaml
+++ b/testdata/policies/repos.yaml
@@ -222,8 +222,8 @@ policy:
       protected: [ master, release-1.3, release-1.2 ]
       branches:
         cgo: false
-        goversion: 1.15
-        upgradefromver: 1.1.0
+        goversion: 1.19
+        upgradefromver: 1.15
         pcprivate: false
         configfile: tib.conf
         versionpackage: github.com/TykTechnologies/tyk-identity-broker/main


### PR DESCRIPTION
Upgrading the version of go used in the release job that runs on each TIB PR from v1.15 to v1.19