### PR TITLE
Use GH_TOKEN for gh cli

### DIFF
--- a/policy/templates/sync/.github/workflows/sync-automation.yml
+++ b/policy/templates/sync/.github/workflows/sync-automation.yml
@@ -89,7 +89,7 @@ jobs:
           git push origin {{`${{ steps.sync-changes.outputs.prbranch }}`}}
           exit 0
         env:
-          GITHUB_TOKEN: {{`${{ secrets.ORG_GH_TOKEN }}`}}
+          GH_TOKEN: {{`${{ secrets.ORG_GH_TOKEN }}`}}
 
       - name: Create PR from the branch.
         id: create-pr
@@ -127,6 +127,6 @@ jobs:
         run: |
           gh pr merge $PULL --auto --squash --subject "[CI] Sync automation: Syncing commits from master" --body "Picking CI changes from the commit $COMMIT"
         env:
-          GITHUB_TOKEN: ${{`{{ secrets.ORG_GH_TOKEN }}`}}
+          GH_TOKEN: ${{`{{ secrets.ORG_GH_TOKEN }}`}}
           PULL: ${{`{{ steps.create-pr.outputs.result }}`}}
           COMMIT: ${{`{{ github.sha }}`}}


### PR DESCRIPTION
Use the ITS token for checkout and gh invocation only - all the other git actions we do are
specific to the repo and the GITHUB_TOKEN has the required repo permissions to do them.