### PR TITLE
[TD-1474]:Remove review request step from sync-automation

### DIFF
--- a/policy/templates/sync/.github/workflows/sync-automation.yml
+++ b/policy/templates/sync/.github/workflows/sync-automation.yml
@@ -109,11 +109,6 @@ jobs:
                       on master.
                       Please make any additional changes required before
                       merging. `});
-            github.rest.pulls.requestReviewers({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: response.data.number,
-              team_reviewers: ['TykTechnologies/devops'] });
             github.rest.issues.addLabels({
               owner:  context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
Review requests for TykTechnologies/devops are
already assigned as a result of having appropriate CODEOWNERS entry.