### PR TITLE
updated the required tests in dahsboard for master and release-5-lts

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -239,7 +239,14 @@ policy:
             release-5-lts:
               active: true
               sourcebranch: master
-              tests: ["1.19","1.19-el7","test (1.19.x, ubuntu-latest, amd64, 15.x)","postgres","sqlite","mongo-official","mongo-mgo"]
+              tests:
+                - "1.19"
+                - "1.19-el7"
+                - "test (1.19.x, ubuntu-latest, amd64, 15.x)"
+                - "postgres"
+                - "sqlite"
+                - "mongo-official"
+                - "mongo-mgo"]
             release-5.0.1:
               active: false
               sourcebranch: release-5-lts

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -201,7 +201,14 @@ policy:
               active: true
               reviewcount: 1
               goversion: 1.19
-              tests: ["1.19","1.19-el7","test (1.19.x, ubuntu-latest, amd64, 15.x)","postgres","sqlite","mongo-official","mongo-mgo"]
+              tests:
+                - "1.19"
+                - "1.19-el7"
+                - "test (1.19.x, ubuntu-latest, amd64, 15.x)"
+                - "postgres"
+                - "sqlite"
+                - "mongo-official"
+                - "mongo-mgo"
             release-4:
               active: false
             release-4.3:
@@ -246,7 +253,7 @@ policy:
                 - "postgres"
                 - "sqlite"
                 - "mongo-official"
-                - "mongo-mgo"]
+                - "mongo-mgo"
             release-5.0.1:
               active: false
               sourcebranch: release-5-lts

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -201,7 +201,7 @@ policy:
               active: true
               reviewcount: 1
               goversion: 1.19
-              tests: ["1.19","1.19-el7","test (1.19.x, ubuntu-latest, amd64, 15.x)","postgres","sqlite","mongo"]
+              tests: ["1.19","1.19-el7","test (1.19.x, ubuntu-latest, amd64, 15.x)","postgres","sqlite","mongo-official","mongo-mgo"]
             release-4:
               active: false
             release-4.3:
@@ -239,6 +239,7 @@ policy:
             release-5-lts:
               active: true
               sourcebranch: master
+              tests: ["1.19","1.19-el7","test (1.19.x, ubuntu-latest, amd64, 15.x)","postgres","sqlite","mongo-official","mongo-mgo"]
             release-5.0.1:
               active: false
               sourcebranch: release-5-lts


### PR DESCRIPTION
Updated the policy about which tests are required to merge into the dashboard master branch and release-5-lts. The check `mongo` not longer exist, and now we have 2: mongo-official and mongo-mgo given that the work of storages has been merged