### PR TITLE
Update goreleaser command in release.yml - releng templates

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.tmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.tmpl
@@ -115,7 +115,7 @@
       - uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist -f ${{`{{ matrix.goreleaser }}`}}
+          args: release --clean -f ${{`{{ matrix.goreleaser }}`}} ${{`{{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot' }}`}}
         env:
           GITHUB_TOKEN: ${{`{{ secrets.GITHUB_TOKEN }}`}}
           CGO_ENABLED: {{ if .Branchvals.Cgo }}1{{ else }}0{{ end }}


### PR DESCRIPTION
Latest portal changes bumps the goreleaser action version to 4. With goreleaser-action at v4 and if checkout is shallow - it looks like goreleaser fails if --snapshot isn't explicitly set in case the trigger isn't a tag push.
Updates the templates to include the fix for this.