### PR TITLE
[TD-2105]: Restore Fix vendor step

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -91,7 +91,6 @@ policy:
           # the respective branches.
           sourcebranch: master
           features:
-            - api-test
           branch:
             master:
               # For any branch other than master, setting active to true also implies
@@ -120,7 +119,6 @@ policy:
               # with el7 support based on the presence of this feature flag.
               features:
                 - go1.19
-                - api-test
             release-5.1:
               active: true
               goversion: 1.19-bullseye
@@ -133,7 +131,7 @@ policy:
                 - "Go 1.15 Redis 6"
               features:
                 - el7
-                - api-test
+                - plugin-compiler-fix-vendor
               goversion: 1.15
             release-5.0.4:
               active: true
@@ -142,14 +140,14 @@ policy:
               goversion: 1.16
               features:
                 - el7
-                - api-test
+                - plugin-compiler-fix-vendor
             release-5-lts:
               active: true
               goversion: 1.16
               tests: ["Go 1.16 Redis 5","1.16-bullseye","1.16-el7"]
               features:
                 - el7
-                - api-test
+                - plugin-compiler-fix-vendor
             release-4.0.14:
               active: true
               sourcebranch: release-4-lts
@@ -157,8 +155,8 @@ policy:
               tests:
                 - "Go 1.15 Redis 6"
               features:
+                - plugin-compiler-fix-vendor
                 - el7
-                - api-test
     tyk-analytics:
       description: >-
         Dashboard for the Tyk API Gateway
@@ -190,52 +188,38 @@ policy:
               goversion: 1.19-bullseye
               features:
                 - go1.19
-                - api-test
-                - ui-test
             release-5.1:
               active: true
               reviewcount: 0
               goversion: 1.19-bullseye
               features:
                 - go1.19
-                - api-test
-                - ui-test
             release-5.1.1:
               active: true
               reviewcount: 0
               goversion: 1.19-bullseye
               features:
                 - go1.19
-                - api-test
-                - ui-test
             release-5.0.4:
               active: true
               sourcebranch: release-5-lts
               tests: ["1.16","1.16-el7","test (1.16.x, ubuntu-latest, amd64, 15.x)","sqlite","mongo-mgo","mongo-official"]
               features:
                 - el7
-                - api-test
-                - ui-test
             release-5-lts:
               active: true
               tests: ["1.16","1.16-el7","test (1.16.x, ubuntu-latest, amd64, 15.x)","sqlite","mongo-mgo","mongo-official"]
               features:
-                - api-test
-                - ui-test
                 - el7
             release-4-lts:
               active: true
               tests: ["1.16","1.16-el7","test (1.16.x, ubuntu-latest, amd64, 15.x)","sqlite","mongo"]
               features:
-                - api-test
-                - ui-test
                 - el7
             release-4.0.14:
               active: true
               tests: ["1.16","1.16-el7","test (1.16.x, ubuntu-latest, amd64, 15.x)","sqlite","mongo"]
               features:
-                - api-test
-                - ui-test
                 - el7
     tyk-identity-broker:
       description: >-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -133,7 +133,6 @@ policy:
                 - "Go 1.15 Redis 6"
               features:
                 - el7
-                - plugin-compiler
                 - api-test
               goversion: 1.15
             release-5.0.4:
@@ -143,7 +142,6 @@ policy:
               goversion: 1.16
               features:
                 - el7
-                - plugin-compiler
                 - api-test
             release-5-lts:
               active: true
@@ -151,7 +149,6 @@ policy:
               tests: ["Go 1.16 Redis 5","1.16-bullseye","1.16-el7"]
               features:
                 - el7
-                - plugin-compiler
                 - api-test
             release-4.0.14:
               active: true
@@ -160,7 +157,6 @@ policy:
               tests:
                 - "Go 1.15 Redis 6"
               features:
-                - plugin-compiler
                 - el7
                 - api-test
     tyk-analytics:

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -97,7 +97,7 @@
             *.txt.sig
             *.txt
 
-  {{- if and (eq .Name "tyk") (not (has "go1.19" .Branchvals.Features) ) }}
+  {{- if and (eq .Name "tyk") (has "plugin-compiler-fix-vendor" .Branchvals.Features) }}
       - name: Fix vendor
         run: |
           mkdir -p /go/src

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -97,6 +97,19 @@
             *.txt.sig
             *.txt
 
+  {{- if and (eq .Name "tyk") (not (has "go1.19" .Branchvals.Features) ) }}
+      - name: Fix vendor
+        run: |
+          mkdir -p /go/src
+          go mod tidy
+          go mod vendor
+          cp -r -f vendor/* /go/src
+          mkdir -p /go/src/github.com/TykTechnologies/tyk
+          cp -r ./* /go/src/github.com/TykTechnologies/tyk
+          find /go/src -name vendor | xargs --no-run-if-empty -d'\n' rm -rf
+          rm -rf vendor
+  {{- end }}
+
       - uses: goreleaser/goreleaser-action@v4
         with:
           version: latest


### PR DESCRIPTION
Restore the fix vendor step in release workflow, which is required
for plugin compiler compatibility for all the branches before the
go 1.19 change.
The templates use the go1.19 feature to conditionally add this
step.
