### PR TITLE
[TD-2096]: Add replace directives to support build numbers

### DIFF
--- a/policy/templates/releng/ci/goreleaser/goreleaser.yml.d/dockers.gotmpl
+++ b/policy/templates/releng/ci/goreleaser/goreleaser.yml.d/dockers.gotmpl
@@ -8,9 +8,9 @@ dockers:
   - ids:
       - std
     image_templates:
-      - "{{$r.DHRepo}}:{{`{{ .Tag }}`}}-{{ $arch }}"
+      - "{{$r.DHRepo}}:{{`{{ replace .Tag "+" "-" }}`}}-{{ $arch }}"
     {{- if $r.CSRepo }}
-      - "{{$r.CSRepo}}:{{`{{ .Tag }}`}}-{{ $arch }}"
+      - "{{$r.CSRepo}}:{{`{{ replace .Tag "+" "-" }}`}}-{{ $arch }}"
     {{- end}}
     build_flag_templates:
       - "--build-arg=PORTS={{ $r.ExposePorts }}"
@@ -57,7 +57,7 @@ dockers:
   - ids:
       - std
     image_templates:
-      - "tykio/tyk-hybrid-docker:{{`{{ .Tag }}`}}-{{ $arch }}"
+      - "tykio/tyk-hybrid-docker:{{`{{ replace .Tag "+" "-" }}`}}-{{ $arch }}"
     build_flag_templates:
       - "--platform=linux/{{ $arch }}"
       - "--label=org.opencontainers.image.created={{`{{.Date}}`}}"


### PR DESCRIPTION
semver versioning has the concept of build numbers, where the same {{Major}}.{{Minor}}.{{Patch}} versions can have incremental revisions/builds with higher build numbers getting higher version precedence( eg: 1.2.3+b2 > 1.2.3+b2).
Docker tags don't support '+' in it, and this PR does an inline replace for this case in goreleaser config.