### PR TITLE
SYSE-274/Change tag policy for ci images

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -151,8 +151,8 @@
             type=ref,event=branch
             type=ref,event=pr
             type=sha,format=long
-            type=semver,pattern=v{{`{{major}}`}}.{{`{{minor}}`}}
-            type=semver,pattern=v{{`{{version}}`}}
+            type=semver,pattern=v{{`{{major}}`}}.{{`{{minor}}`}},prefix=v
+            type=semver,pattern=v{{`{{version}}`}},prefix=v
 
       - name: CI push
         shell: bash

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -150,8 +150,7 @@
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha
-            type=sha,format=long,prefix=
+            type=sha,format=long
             type=semver,pattern=v{{`{{major}}`}}.{{`{{minor}}`}}
             type=semver,pattern=v{{`{{version}}`}}
 


### PR DESCRIPTION
This PR is aimed to rework the tag for CI images, so repo can be clean out by using policy based on prefixes