### PR TITLE
[SYSE-15]: Additional releng changes

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -55,7 +55,14 @@ policy:
       # The default config file used by the application.
       configfile: tyk.conf
       # The go package which contains the `VERSION` string for this REPO.
-      versionpackage: github.com/TykTechnologies/tyk/gateway
+      versionpackage: github.com/TykTechnologies/tyk/internal/build
+      # The keys to be used for the version related variables that needs to
+      # be filled in during build time.
+      versionkeys:
+        version: Version
+        commit: Commit
+        builddate: BuildDate
+        builtby: BuiltBy
       # Min number of reviews needed for a PR
       reviewcount: 0
       # Should conversations be resolved before merging
@@ -89,7 +96,7 @@ policy:
           features:
             - el7
             - plugin-compiler-fix-vendor
- 
+
     tyk-analytics:
       description: >-
         Dashboard for the Tyk API Gateway
@@ -105,8 +112,13 @@ policy:
       pcprivate: false
       configfile: tyk_analytics.conf
       versionpackage: github.com/TykTechnologies/tyk-analytics/dashboard
+      versionkeys:
+        version: VERSION
+        commit: Commit
+        builddate: buildDate
+        builtby: builtBy
       convos: false
-      sourcebranch: master          
+      sourcebranch: master
       buildenv: 1.16
       features:
         - el7
@@ -136,6 +148,11 @@ policy:
       pcprivate: false
       configfile: tib.conf
       versionpackage: github.com/TykTechnologies/tyk-identity-broker/main
+      versionkeys:
+        version: VERSION
+        commit: Commit
+        builddate: buildDate
+        builtby: builtBy
       buildenv: 1.19-bullseye
       tests: ["1.19-bullseye"]
       branches:
@@ -157,13 +174,18 @@ policy:
       pcprivate: true
       configfile: tyk_sink.conf
       versionpackage: github.com/TykTechnologies/tyk-sink/main
-      sourcebranch: master        
+      versionkeys:
+        version: VERSION
+        commit: Commit
+        builddate: buildDate
+        builtby: builtBy
+      sourcebranch: master
       buildenv: 1.19-bullseye
       tests: ["1.19-bullseye", "postgres", "mongo-official", "mongo-mgo"]
       branches:
         master:
           reviewcount: 1
-            
+
     portal:
       description: >-
         Developer portal for the Tyk API Gateway
@@ -177,7 +199,12 @@ policy:
       upgradefromver: 1.0.0
       pcprivate: false
       configfile: portal.conf
-      versionpackage: github.com/TykTechnologies/portal/core
+      versionpackage: github.com/TykTechnologies/portal/model/version
+      versionkeys:
+        version: version
+        commit: commit
+        builddate: buildDate
+        builtby: buildBy
       convos: false
       tests:
         - "test (1.19.x, ubuntu-latest, amd64, 15.x)"
@@ -206,6 +233,11 @@ policy:
       pcprivate: false
       configfile: pump.conf
       versionpackage: github.com/TykTechnologies/tyk-pump/pumps
+      versionkeys:
+        version: VERSION
+        commit: Commit
+        builddate: buildDate
+        builtby: builtBy
       convos: false
       sourcebranch: master
       buildenv: 1.19-bullseye

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -33,6 +33,7 @@ type Policies struct {
 	Cgo            bool
 	ConfigFile     string
 	VersionPackage string
+	VersionKeys    versionKeys
 	UpgradeFromVer string
 	Features       []string
 	Branches       map[string]branchVals `copier:"-"`
@@ -48,12 +49,22 @@ type branchVals struct {
 	Cgo            bool
 	ConfigFile     string
 	VersionPackage string
+	VersionKeys    versionKeys
 	UpgradeFromVer string
 	Convos         bool
 	ReviewCount    int
 	Tests          []string
 	SourceBranch   string
 	Features       []string
+}
+
+// versionKeys holds the information about all the version
+// related variables set during the binary build.
+type versionKeys struct {
+	Version   string
+	Commit    string
+	BuildDate string
+	BuiltBy   string
 }
 
 // RepoPolicy is used to render templates. It provides an abstraction
@@ -76,6 +87,7 @@ type RepoPolicy struct {
 	Cgo            bool
 	ConfigFile     string
 	VersionPackage string
+	VersionKeys    versionKeys
 	UpgradeFromVer string
 	Branch         string
 	Branchvals     branchVals

--- a/policy/templates/el7/ci/goreleaser/goreleaser-el7.yml.d/builds.gotmpl
+++ b/policy/templates/el7/ci/goreleaser/goreleaser-el7.yml.d/builds.gotmpl
@@ -2,7 +2,7 @@
 builds:
   - id: std
     ldflags:
-      - -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
     goos:
       - linux
     goarch:

--- a/policy/templates/el7/ci/goreleaser/goreleaser-el7.yml.d/cgo_builds.tmpl
+++ b/policy/templates/el7/ci/goreleaser/goreleaser-el7.yml.d/cgo_builds.tmpl
@@ -9,7 +9,7 @@ builds:
       - -tags=goplugin
   {{- end}}
     ldflags:
-      - -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{ .Branchvals.VersionPackage }}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
     goos:
       - linux
     goarch:
@@ -24,7 +24,7 @@ builds:
       - -tags=goplugin
   {{- end}}
     ldflags:
-      - -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:
@@ -41,7 +41,7 @@ builds:
       - -tags=goplugin
   {{- end}} {{/* tyk */}}
     ldflags:
-      - -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
     env:
       - CC=s390x-linux-gnu-gcc
     goos:
@@ -56,7 +56,9 @@ builds:
       - -v
       - -x
     ldflags:
-      - -s -w -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -s
+      - -w
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
       - "-X '{{.Branchvals.VersionPackage}}.pk=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF0YmZxNUtTYksyK2Z2Y1ozNlJ4dQpXSTJ1UnBHK25mb09zNldsaEJra3pZUTZNTlZpanJyMDh5ampadXRhU2NLMXN2YzJncitBdHUzUCtjOTJvdjBoCnIxQVVCZzd2WElwOTZFKzh3WDU4cld6cnNLa0JJKzBuTzBVbEtqeUFYelFpTnBCdkhEZEplbTVqbHRSeHJDYTAKd3kxOHJQbkpOdUx0WG15TjlGSEJXQ1o4YnZLOFJzaGFCSWJ1cUltK1FlT1k5RlZoS3MrWkFBeTBmMmpJNURNaAoxQ2FHQUhpN1RqR2NtNUpJTzFOZUszQWFNTUhuK2NLVVE4cG5ZOS92R2hPODZCQ2dzVzhjeXZ1d2JzT3pCM1I3CkRiangxbXFDVUtsUzl2Yzl2dHRxN0RtVWVqaWV3a0g2ZlZhUDZiU3AxcFJFMkFROHlGU0toc1VacU9KL0h4VWEKSWV5eDNoRmowcWh3ZjB2dm1XeHN3ZE4vdWd0VWRSZFRHdldyR0lZOWRpR0R5T3c3TkhBUnZEN2E5Tk1QT1IrTQpjSXJCdkNUT2ViWnAvNTh6Tlo5TUJZUFBQY05JNzUrZlk5TEExQk5Yd0ErZmZHaGlrMjJnVUg2djdsc3pVQWUrCnBWSGJZVU1mL2t1djJmNDVRWHdLRzJxSnFtZ3Nxdkw5eHd5OEJrWTc0dDltREdTTEhtV29YNTlUYjlzQ3ZqNmIKd3hnNU93R0RXSTJPNjhjTkVtYVpPd2QySGoxZ0pVOE1zbkhiUHF2SlhKNjVDYzRHTHBMSElQaGxrd0hkQlV0eApnK1dqbnoyVEdPT2wyaWhUMWVBM2pQUUFyejk4VFUwMjhYbE1xWEgzNE5hN3owb003dkF0VXpUbmwrOWNRSS85Cm45YUlqQVJYclNsNWd0azRVZkFDSURVQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo='"
     goos:
       - linux

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -141,11 +141,13 @@
           mask-aws-account-id: false
 
       - uses: aws-actions/amazon-ecr-login@v1
+        if: {{`${{ matrix.golang_cross == '` }}{{.Branchvals.Buildenv}}{{`' }}`}}
         id: ecr
         with:
           mask-password: 'true'
 
       - name: Docker metadata for CI
+        if: {{`${{ matrix.golang_cross == '` }}{{.Branchvals.Buildenv}}{{`' }}`}}
         id: metadata
         uses: docker/metadata-action@v4
         with:
@@ -160,6 +162,7 @@
             type=semver,pattern=v{{`{{version}}`}},prefix=v
 
       - name: CI push
+        if: {{`${{ matrix.golang_cross == '` }}{{.Branchvals.Buildenv}}{{`' }}`}}
         shell: bash
         env:
           t: {{`${{ steps.metadata.outputs.tags }}`}}

--- a/policy/templates/releng/.github/workflows/release.yml.d/tests.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/tests.gotmpl
@@ -272,8 +272,11 @@
           mask-password: 'true'
 {{- end }}
       - name: Run ci/tests
+{{- if not (eq .Name "tyk") }}
+        if: startsWith(github.ref, 'refs/tags')
+{{- end }}
         shell: bash
-        env:        
+        env:
           GITHUB_TAG: {{`${{ github.ref }}`}}
 {{- if eq .Name "tyk" }}
           GATEWAY_IMAGE: {{`${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}`}}
@@ -281,15 +284,12 @@
 {{- end }}
   {{- if or (eq .Name "tyk-analytics") (eq .Name "tyk-sink") }}
           TYK_DB_LICENSEKEY: {{`${{ secrets.DASH_LICENSE }}`}}
+  {{- end }}
   {{- if eq .Name "tyk-sink" }}
           TYK_MDCB_LICENSE: {{`${{ secrets.MDCB_LICENSE }}`}}
-  {{- end }}        
   {{- end }}
         run: |
           set -eaxo pipefail
-          if [ ! -d smoke-tests ]; then
-             echo "::warning No repo specific smoke tests defined"
-          fi
           if [ ! -d ci/tests ]; then
              echo "::warning No ci tests defined"
              exit 0
@@ -303,6 +303,36 @@
                   cd -
               fi
           done
+
+      - name: Run smoke-tests
+{{- if eq .Name "tyk" }}
+        # This job only runs whenever a tag is created. A tag is required
+        # for a functional plugin compiler build for when the GO_GET=1 env
+        # is provided. The plugin compiler cannot fetch the referenced
+        # commit from a PR, but requires a /heads or /tags reference.
+        #
+        # See https://github.com/golang/go/issues/31191 for more info.
+{{- end }}
+        if: startsWith(github.ref, 'refs/tags')
+        shell: bash
+        env:
+          GITHUB_TAG: {{`${{ github.ref }}`}}
+{{- if eq .Name "tyk" }}
+          GATEWAY_IMAGE: {{`${{ steps.ecr.outputs.registry }}/tyk:sha-${{ github.sha }}`}}
+          PLUGIN_COMPILER_IMAGE: {{`${{ steps.ecr.outputs.registry }}/tyk-plugin-compiler:sha-${{ github.sha }}`}}
+{{- end }}
+  {{- if or (eq .Name "tyk-analytics") (eq .Name "tyk-sink") }}
+          TYK_DB_LICENSEKEY: {{`${{ secrets.DASH_LICENSE }}`}}
+  {{- end }}
+  {{- if eq .Name "tyk-sink" }}
+          TYK_MDCB_LICENSE: {{`${{ secrets.MDCB_LICENSE }}`}}
+  {{- end }}
+        run: |
+          set -eaxo pipefail
+          if [ ! -d smoke-tests ]; then
+             echo "::warning No ci tests defined"
+             exit 0
+          fi
           for d in smoke-tests/*/
           do
               echo Attempting to test $d

--- a/policy/templates/releng/ci/goreleaser/goreleaser.yml.d/builds.gotmpl
+++ b/policy/templates/releng/ci/goreleaser/goreleaser.yml.d/builds.gotmpl
@@ -2,7 +2,7 @@
 builds:
   - id: std
     ldflags:
-      - -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuiltBy}}=goreleaser
     goos:
       - linux
     goarch:

--- a/policy/templates/releng/ci/goreleaser/goreleaser.yml.d/cgo_builds.gotmpl
+++ b/policy/templates/releng/ci/goreleaser/goreleaser.yml.d/cgo_builds.gotmpl
@@ -9,7 +9,7 @@ builds:
       - -tags=goplugin
   {{- end}} {{/* tyk */}}
     ldflags:
-      - -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{ .Branchvals.VersionPackage }}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuiltBy}}=goreleaser
     goos:
       - linux
     goarch:
@@ -24,7 +24,7 @@ builds:
       - -tags=goplugin
   {{- end}} {{/* tyk */}}
     ldflags:
-      - -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuiltBy}}=goreleaser
     env:
       - CC=aarch64-linux-gnu-gcc
     goos:
@@ -41,7 +41,7 @@ builds:
       - -tags=goplugin
   {{- end}} {{/* tyk */}}
     ldflags:
-      - -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuiltBy}}=goreleaser
     env:
       - CC=s390x-linux-gnu-gcc
     goos:
@@ -56,7 +56,9 @@ builds:
       - -v
       - -x
     ldflags:
-      - -s -w -X {{.Branchvals.VersionPackage}}.VERSION={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.buildDate={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.builtBy=goreleaser
+      - -s
+      - -w
+      - -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Version}}={{`{{.Version}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.Commit}}={{`{{.FullCommit}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuildDate}}={{`{{.Date}}`}} -X {{.Branchvals.VersionPackage}}.{{.Branchvals.VersionKeys.BuiltBy}}=goreleaser
       - "-X '{{.Branchvals.VersionPackage}}.pk=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF0YmZxNUtTYksyK2Z2Y1ozNlJ4dQpXSTJ1UnBHK25mb09zNldsaEJra3pZUTZNTlZpanJyMDh5ampadXRhU2NLMXN2YzJncitBdHUzUCtjOTJvdjBoCnIxQVVCZzd2WElwOTZFKzh3WDU4cld6cnNLa0JJKzBuTzBVbEtqeUFYelFpTnBCdkhEZEplbTVqbHRSeHJDYTAKd3kxOHJQbkpOdUx0WG15TjlGSEJXQ1o4YnZLOFJzaGFCSWJ1cUltK1FlT1k5RlZoS3MrWkFBeTBmMmpJNURNaAoxQ2FHQUhpN1RqR2NtNUpJTzFOZUszQWFNTUhuK2NLVVE4cG5ZOS92R2hPODZCQ2dzVzhjeXZ1d2JzT3pCM1I3CkRiangxbXFDVUtsUzl2Yzl2dHRxN0RtVWVqaWV3a0g2ZlZhUDZiU3AxcFJFMkFROHlGU0toc1VacU9KL0h4VWEKSWV5eDNoRmowcWh3ZjB2dm1XeHN3ZE4vdWd0VWRSZFRHdldyR0lZOWRpR0R5T3c3TkhBUnZEN2E5Tk1QT1IrTQpjSXJCdkNUT2ViWnAvNTh6Tlo5TUJZUFBQY05JNzUrZlk5TEExQk5Yd0ErZmZHaGlrMjJnVUg2djdsc3pVQWUrCnBWSGJZVU1mL2t1djJmNDVRWHdLRzJxSnFtZ3Nxdkw5eHd5OEJrWTc0dDltREdTTEhtV29YNTlUYjlzQ3ZqNmIKd3hnNU93R0RXSTJPNjhjTkVtYVpPd2QySGoxZ0pVOE1zbkhiUHF2SlhKNjVDYzRHTHBMSElQaGxrd0hkQlV0eApnK1dqbnoyVEdPT2wyaWhUMWVBM2pQUUFyejk4VFUwMjhYbE1xWEgzNE5hN3owb003dkF0VXpUbmwrOWNRSS85Cm45YUlqQVJYclNsNWd0azRVZkFDSURVQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo='"
     goos:
       - linux


### PR DESCRIPTION
- Smoke tests, ci/tests: Adds the split test strategy used in gateway
- Version package: Along with version package, there are changes in gateway and portal which changes the variables inside the package too. This adds another configuration item `versionkeys` that supports this.
- analytics: Do ci push only on cgo matrix run.