### PR TITLE
Add old update-config-docs.yml to deletedfiles policies

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -20,6 +20,7 @@ policy:
     deletedfiles:
       - .github/workflows/del-env.yml
       - .github/workflows/sync-automation.yml
+      - .github/workflows/update-config-docs.yml
       - bin/dist_push.sh
       - bin/dist_build.sh
       - bin/integration_build.sh


### PR DESCRIPTION
A docs sync action was triggered from 4-lts and is unwanted. This policy change adds `update-config-docs.yml` action to the deletedfiles definition.

It looks like [SYSE-292](https://tyktech.atlassian.net/browse/SYSE-292) was commited but not applied for 4-LTS (yet?). I opened a PR removing the actions on 4-LTS and decided to update the policies if there are other target branches to clean up.

Via: https://github.com/TykTechnologies/tyk/pull/5931

[SYSE-292]: https://tyktech.atlassian.net/browse/SYSE-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ