### PR TITLE
Releng templates: Add repo name conditional for tyk-sink in upgrade tests

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -67,9 +67,6 @@ policy:
         # recently generated packages. Make sure that this is a version
         # that has candidate packages for all our supported OSes and archs.
         upgradefromver: 3.0.8
-        # This signifies whether the packagecloud repo for this git repo
-        # is private or not.
-        pcprivate: false
         # The default config file used by the application.
         configfile: tyk.conf
         # The go package which contains the `VERSION` string for this REPO.
@@ -110,7 +107,6 @@ policy:
         packagename: tyk-dashboard
         cgo: true
         upgradefromver: 3.0.9
-        pcprivate: false
         configfile: tyk_analytics.conf
         versionpackage: github.com/TykTechnologies/tyk-analytics/dashboard/internal/build
         sourcebranch: master          
@@ -139,7 +135,6 @@ policy:
         packagename: tyk-identity-broker
         cgo: false
         upgradefromver: 1.1.0
-        pcprivate: false
         configfile: tib.conf
         versionpackage: github.com/TykTechnologies/tyk-identity-broker/main
         buildenv: 1.21-bullseye
@@ -149,7 +144,7 @@ policy:
       tyk-sink:
         description: >-
          Tyk RPC server backend (bridge)
-        pcrepo: tyk-mdcb-stable
+        pcrepo: tyk-mdcb
         dhrepo: tykio/tyk-mdcb-docker
         csrepo: docker.tyk.io/tyk-sink/tyk-sink
         exposeports: 80
@@ -157,7 +152,6 @@ policy:
         packagename: tyk-sink
         cgo: false
         upgradefromver: 1.8.2
-        pcprivate: false
         configfile: tyk_sink.conf
         versionpackage: github.com/TykTechnologies/tyk-sink/main
         sourcebranch: master        
@@ -177,7 +171,6 @@ policy:
         packagename: portal
         cgo: true
         upgradefromver: 1.0.0
-        pcprivate: false
         configfile: portal.conf
         versionpackage: github.com/TykTechnologies/portal/model/version
         baseimage: debian:trixie-slim
@@ -196,7 +189,6 @@ policy:
         packagename: tyk-pump
         cgo: false
         upgradefromver: 1.6.0
-        pcprivate: false
         configfile: pump.conf
         versionpackage: github.com/TykTechnologies/tyk-pump/pumps
         sourcebranch: master
@@ -204,4 +196,7 @@ policy:
         branches:
           master:
             features:
+              - s390x
+          release-1.9:
+            feature:
               - s390x

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -23,7 +23,6 @@ type repoConfig struct {
 	PCRepo         string
 	DHRepo         string
 	CSRepo         string
-	PCPrivate      bool
 	PackageName    string
 	Reviewers      []string
 	ExposePorts    string
@@ -74,7 +73,6 @@ type RepoPolicy struct {
 	Name           string
 	Description    string
 	Default        string
-	PCPrivate      bool
 	PCRepo         string
 	DHRepo         string
 	CSRepo         string

--- a/policy/templates/releng/.github/workflows/release.yml.d/smoke-tests.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/smoke-tests.gotmpl
@@ -1,4 +1,9 @@
 {{ define "smoke-tests" }}
+
+{{- $pcrepo :=  $.PCRepo }}
+{{if eq .Name "tyk-sink" }}
+  {{ $pcrepo =  print $.PCRepo "-stable" }}
+{{ end }}
   upgrade-deb:
     services:
       httpbin.org:
@@ -40,11 +45,7 @@
           ARG TARGETARCH
           COPY {{ .PackageName }}*_${TARGETARCH}.deb /{{ .PackageName }}.deb
           RUN apt-get update && apt-get install -y curl
-  {{- if .PCPrivate }}
-          RUN curl -u {{`${{ secrets.PACKAGECLOUD_MASTER_TOKEN }}`}}: -fsSL https://packagecloud.io/install/repositories/tyk/{{ .PCRepo }}/script.deb.sh | bash && apt-get install -y {{ .PackageName }}={{ .Branchvals.UpgradeFromVer }}
-  {{- else }}
-          RUN curl -fsSL https://packagecloud.io/install/repositories/tyk/{{ .PCRepo }}/script.deb.sh | bash && apt-get install -y {{ .PackageName }}={{ .Branchvals.UpgradeFromVer }}
-  {{- end }}
+          RUN curl -fsSL https://packagecloud.io/install/repositories/tyk/{{ $pcrepo }}/script.deb.sh | bash && apt-get install -y {{ .PackageName }}={{ .Branchvals.UpgradeFromVer }}
           RUN dpkg -i {{ .PackageName }}.deb
   {{- if eq .Name "tyk" }}
           RUN apt-get install -y jq
@@ -107,14 +108,8 @@
           COPY {{ .PackageName }}*.x86_64.rpm /{{ .PackageName }}.rpm
           RUN command -v curl || yum install -y curl
           RUN command -v useradd || yum install -y shadow-utils
-  {{- if .PCPrivate }}
-          RUN curl -u {{`${{ secrets.PACKAGECLOUD_MASTER_TOKEN }}`}}: -s https://packagecloud.io/install/repositories/tyk/{{ .PCRepo }}/script.rpm.sh | bash && yum install -y {{ .PackageName }}-{{ .Branchvals.UpgradeFromVer }}-1
-
-  {{- else }}
-          RUN curl -fsSL https://packagecloud.io/install/repositories/tyk/{{ .PCRepo }}/script.rpm.sh | bash && yum install -y {{ .PackageName }}-{{ .Branchvals.UpgradeFromVer }}-1
-
-  {{- end }}
-          RUN curl https://keyserver.tyk.io/tyk.io.rpm.signing.key.2020 -o {{ .PCRepo }}.key && rpm --import {{ .PCRepo }}.key
+          RUN curl -fsSL https://packagecloud.io/install/repositories/tyk/{{ $pcrepo }}/script.rpm.sh | bash && yum install -y {{ .PackageName }}-{{ .Branchvals.UpgradeFromVer }}-1
+          RUN curl https://keyserver.tyk.io/tyk.io.rpm.signing.key.2020 -o {{ $pcrepo }}.key && rpm --import {{ $pcrepo }}.key
           RUN rpm --checksig {{ .PackageName }}.rpm
           RUN rpm -Uvh --force {{ .PackageName }}.rpm
   {{- if eq .Name "tyk" }}


### PR DESCRIPTION
tyk-sink has a different packagecloud repo name format from the other repos. Handle this conditionally in the upgrade tests templates.

Also removes PCPrivate variable since we don't have any private packagecloud repos anymore.