### PR TITLE
set pipefail

### DIFF
--- a/policy/templates/subtemplates/auto/api-tests.gotmpl
+++ b/policy/templates/subtemplates/auto/api-tests.gotmpl
@@ -61,6 +61,7 @@
         working-directory: auto
         id: test_execution
         run: |
+          set -o pipefail
           echo "### API tests {{`${{ matrix.db }} ${{ matrix.conf }}`}}" >> $GITHUB_STEP_SUMMARY
           if docker run --rm --network auto_default --env-file pytest.env -v {{`${{ github.workspace }}`}}/reports:/app/reports \
              {{`${{ steps.ecr.outputs.registry }}/tyk-automated-tests:${{ needs.test-controller.outputs.gd_tag }}`}} \


### PR DESCRIPTION
Set pipefail to fix regression tests not reporting any failure. This is critical