### PR TITLE
Fix version package for tyk-dashboard

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -109,7 +109,7 @@ policy:
         cgo: true
         upgradefromver: 3.0.9
         configfile: tyk_analytics.conf
-        versionpackage: github.com/TykTechnologies/tyk-analytics/dashboard/internal/build
+        versionpackage: github.com/TykTechnologies/tyk-analytics/internal/build
         sourcebranch: master          
         buildenv: 1.21-bullseye
         features:


### PR DESCRIPTION
An incorrect path was listed in dashboard for the version package, this PR corrects the path.

Should be applied to tyk-analytics 5-LTS and 5.3/master, for the upcoming 5.3.0 and 5.0.11 releases.