### PR TITLE
Override isn't a valid input for upload-artifact@v4

### DIFF
--- a/policy/templates/subtemplates/auto/api-tests.gotmpl
+++ b/policy/templates/subtemplates/auto/api-tests.gotmpl
@@ -95,6 +95,7 @@
           name: docker-compose-logs-api-{{`${{ matrix.db }}`}}-{{`${{ matrix.conf }}`}}-{{`${{ github.run_id }}`}}
           path: {{`${{ github.workspace }}`}}/docker-compose-api.log
           retention-days: 3
+          overwrite: true
 
       - name: Archive Integration tests report
         if: always() 
@@ -103,6 +104,7 @@
             name: api-test-report-{{`${{ matrix.db }}`}}-{{`${{ matrix.conf }}`}}-{{`${{ github.run_id }}`}}
             retention-days: 3
             path: {{`${{ github.workspace }}`}}/reports
+            overwrite: true
 
       - name: Fetch commit author
         if: failure() && steps.test_execution.outcome != 'success' && github.event_name == 'push'

--- a/policy/templates/subtemplates/auto/api-tests.gotmpl
+++ b/policy/templates/subtemplates/auto/api-tests.gotmpl
@@ -95,7 +95,6 @@
           name: docker-compose-logs-api-{{`${{ matrix.db }}`}}-{{`${{ matrix.conf }}`}}-{{`${{ github.run_id }}`}}
           path: {{`${{ github.workspace }}`}}/docker-compose-api.log
           retention-days: 3
-          override: true
 
       - name: Archive Integration tests report
         if: always() 
@@ -104,7 +103,6 @@
             name: api-test-report-{{`${{ matrix.db }}`}}-{{`${{ matrix.conf }}`}}-{{`${{ github.run_id }}`}}
             retention-days: 3
             path: {{`${{ github.workspace }}`}}/reports
-            override: true
 
       - name: Fetch commit author
         if: failure() && steps.test_execution.outcome != 'success' && github.event_name == 'push'

--- a/policy/templates/subtemplates/auto/ui-tests.gotmpl
+++ b/policy/templates/subtemplates/auto/ui-tests.gotmpl
@@ -110,7 +110,6 @@
           name: docker-compose-logs-ui-{{`${{ matrix.db }}`}}-{{`${{ matrix.conf }}`}}-{{`${{ github.run_id }}`}}
           path: {{`${{ github.workspace }}`}}/docker-compose-ui.log
           retention-days: 3
-          override: true
       - name: Upload Playwright Test Report to S3
         if: failure() && steps.ui_test_execution.outcome != 'success' && steps.env_up.outcome == 'success'
         run:

--- a/policy/templates/subtemplates/auto/ui-tests.gotmpl
+++ b/policy/templates/subtemplates/auto/ui-tests.gotmpl
@@ -110,6 +110,7 @@
           name: docker-compose-logs-ui-{{`${{ matrix.db }}`}}-{{`${{ matrix.conf }}`}}-{{`${{ github.run_id }}`}}
           path: {{`${{ github.workspace }}`}}/docker-compose-ui.log
           retention-days: 3
+          overwrite: true
       - name: Upload Playwright Test Report to S3
         if: failure() && steps.ui_test_execution.outcome != 'success' && steps.env_up.outcome == 'success'
         run:


### PR DESCRIPTION
`Override` doesn't seem to be a valid option for upload-artifact@v4.
See the warning on the run below:
https://github.com/TykTechnologies/tyk/actions/runs/8262826493/job/22603310931?pr=6138#step:11:1