### PR TITLE
Update portal go version

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -178,10 +178,6 @@ policy:
         buildenv: 1.21-bullseye
         branches:
           master:
-            baseimage: debian:bookworm-slim
-            buildenv: 1.21-bullseye
-          release-1.8.0:
-            buildenv: 1.19-bullseye
 
       tyk-pump:
         description: >-

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -175,9 +175,13 @@ policy:
         configfile: portal.conf
         versionpackage: github.com/TykTechnologies/portal/model/version
         baseimage: debian:bookworm-slim
-        buildenv: 1.19-bullseye
+        buildenv: 1.21-bullseye
         branches:
           master:
+            baseimage: debian:bookworm-slim
+            buildenv: 1.21-bullseye
+          release-1.8.0:
+            buildenv: 1.19-bullseye
 
       tyk-pump:
         description: >-


### PR DESCRIPTION
Updates portal go version to 1.21 in master branch. The previous release branch `release-1.8.0` should stay in 1.19