### PR TITLE
SYSE-356: Fix plugin compiler support for lts branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,12 @@ SHELL 	:= bash
 VERSION := $(shell git describe --tags)
 COMMIT 	:= $(shell git rev-list -1 HEAD)
 BUILD_DATE := $(shell date +%FT%T%z)
-SRC 	:= $(shell find cmd confgen config orgs policy -name '*.go' -o -regex '.*\.(go)?tmpl' -o -regex '.*\.ya?ml')
+ifeq ($(shell uname),Linux)
+SRC 	:= $(shell find cmd confgen config orgs policy -regextype egrep -name '*.go' -o -regex '.*\.(go)?tmpl' -o -regex '.*\.ya?ml')
+endif
+ifeq ($(shell uname),Darwin)
+SRC 	:= $(shell find -E cmd confgen config orgs policy -name '*.go' -o -regex '.*\.(go)?tmpl' -o -regex '.*\.ya?ml')
+endif
 
 REPOS        ?= tyk tyk-analytics tyk-pump tyk-identity-broker tyk-sink portal
 GITHUB_TOKEN ?= $(shell pass me/github)

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -110,7 +110,7 @@
           chmod +x /tmp/build.sh
           docker run --rm --privileged -e GITHUB_TOKEN={{`${{ github.token }}`}} \
           -e GOPRIVATE=github.com/TykTechnologies                                \
-          {{ if and (eq .Name "tyk") (has "plugin-compiler-fix-vendor" .Branchvals.Features) -}}
+          {{ if has "plugin-compiler-fix-vendor" .Branchvals.Features -}}
           -e GO111MODULE=off                                                     \
           {{ end -}}
           -e DEBVERS='{{`${{ matrix.debvers }}`}}'                               \

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -110,7 +110,7 @@
           chmod +x /tmp/build.sh
           docker run --rm --privileged -e GITHUB_TOKEN={{`${{ github.token }}`}} \
           -e GOPRIVATE=github.com/TykTechnologies                                \
-          -e GO111MODULE={{if and (eq .Name "tyk") (hasSuffix .Branch "-lts" ) }}off{{else}}on{{end}} \
+          -e GO111MODULE={{if and (eq .Name "tyk") (hasSuffix "-lts" .Branch ) }}off{{else}}on{{end}} \
           -e DEBVERS='{{`${{ matrix.debvers }}`}}'                               \
           -e RPMVERS='{{`${{ matrix.rpmvers }}`}}'                               \
           -e CGO_ENABLED={{`${{ matrix.cgo }}`}}                                 \

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -94,7 +94,7 @@
         run: |
           echo '#!/bin/sh
           ci/bin/unlock-agent.sh
-          {{ if and (eq .Name "tyk") (has "plugin-compiler-fix-vendor" .Branchvals.Features) -}}
+          {{ if has "plugin-compiler-fix-vendor" .Branchvals.Features -}}
           mkdir -p /go/src
           GO111MODULE=on go mod tidy
           GO111MODULE=on go mod vendor

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -96,8 +96,8 @@
           ci/bin/unlock-agent.sh
           {{ if and (eq .Name "tyk") (has "plugin-compiler-fix-vendor" .Branchvals.Features) -}}
           mkdir -p /go/src
-          go mod tidy
-          go mod vendor
+          GO111MODULE=on go mod tidy
+          GO111MODULE=on go mod vendor
           cp -r -f vendor/* /go/src
           mkdir -p /go/src/github.com/TykTechnologies/tyk
           cp -r ./* /go/src/github.com/TykTechnologies/tyk
@@ -110,7 +110,9 @@
           chmod +x /tmp/build.sh
           docker run --rm --privileged -e GITHUB_TOKEN={{`${{ github.token }}`}} \
           -e GOPRIVATE=github.com/TykTechnologies                                \
-          -e GO111MODULE={{if and (eq .Name "tyk") (hasSuffix "-lts" .Branch ) }}off{{else}}on{{end}} \
+          {{ if and (eq .Name "tyk") (has "plugin-compiler-fix-vendor" .Branchvals.Features) -}}
+          -e GO111MODULE=off                                                     \
+          {{ end -}}
           -e DEBVERS='{{`${{ matrix.debvers }}`}}'                               \
           -e RPMVERS='{{`${{ matrix.rpmvers }}`}}'                               \
           -e CGO_ENABLED={{`${{ matrix.cgo }}`}}                                 \


### PR DESCRIPTION
Fix plugin compiler support for `release-5-lts`.
We already have the feature `plugin-compiler-fix-vendor` feature added to the release-4-lts and release-5-lts config. So using that instead of the suffix check.