### PR TITLE
[QA-1494] Update env and browser installation for UI

### DIFF
--- a/policy/templates/subtemplates/auto/ui-tests.gotmpl
+++ b/policy/templates/subtemplates/auto/ui-tests.gotmpl
@@ -68,13 +68,12 @@
           # bring up env, the project name is important
           docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f {{`${{ matrix.db }}`}}.yml --env-file versions.env --profile master-datacenter up --quiet-pull -d
           ./dash-bootstrap.sh http://localhost:3000
-          docker compose -p auto -f pro-ha.yml -f deps_pro-ha.yml -f {{`${{ matrix.db }}`}}.yml --env-file versions.env --profile slave-datacenter up --quiet-pull -d
       - name: Install test dependecies
         run: |
           npm ci
         working-directory: tests/ui
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
         working-directory: tests/ui
       - name: Execute UI tests
         id: ui_test_execution


### PR DESCRIPTION
Changes for UI tests in release job:
- delete installing mdcb on env (on-prem is enough for UI tests)
- installing just chromium browser