### PR TITLE
[SYSE-337]: Fixes in el7, and s390x feature conditions

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -90,17 +90,17 @@ policy:
               - auto-test
           release-4-lts:
             features:
-              - el7
               - plugin-compiler-fix-vendor
+              - python-support
             buildenv: 1.15
           release-5-lts:
             buildenv: 1.16
             deletedfiles:
               - .github/workflows/api-tests.yml
             features:
-              - el7
               - plugin-compiler-fix-vendor
               - auto-test
+              - python-support
 
       tyk-analytics:
         description: >-
@@ -115,7 +115,7 @@ policy:
         upgradefromver: 3.0.9
         configfile: tyk_analytics.conf
         versionpackage: github.com/TykTechnologies/tyk-analytics/internal/build
-        sourcebranch: master          
+        sourcebranch: master
         buildenv: 1.21-bullseye
         features:
           - el7

--- a/policy/templates/el7/ci/goreleaser/goreleaser-el7.yml.d/builds.gotmpl
+++ b/policy/templates/el7/ci/goreleaser/goreleaser-el7.yml.d/builds.gotmpl
@@ -11,7 +11,9 @@ builds:
     goarch:
       - amd64
       - arm64
+{{ if has "s390x" .Branchvals.Features }}
       - s390x
+{{ end }}
     binary: {{.Binary}}
 {{end}}
 

--- a/policy/templates/el7/ci/goreleaser/goreleaser-el7.yml.d/cgo_builds.tmpl
+++ b/policy/templates/el7/ci/goreleaser/goreleaser-el7.yml.d/cgo_builds.tmpl
@@ -38,6 +38,7 @@ builds:
     goarch:
       - arm64
     binary: {{.Binary}}
+  {{ if has "s390x" .Branchvals.Features -}}
   - id: std-s390x
   {{- if eq .Name "tyk" }}
     flags:
@@ -58,22 +59,5 @@ builds:
     goarch:
       - s390x
     binary: {{.Binary}}
-  {{- if eq .Name "tyk-analytics"}}
-  # With special license pubkey
-  - id: payg
-    flags:
-      - -v
-      - -x
-    ldflags:
-      - -s -w -X {{.Branchvals.VersionPackage}}.Version={{`{{.Version}}`}}
-      - -X {{.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}}
-      - -X {{.Branchvals.VersionPackage}}.BuildDate={{`{{.Date}}`}}
-      - -X {{.Branchvals.VersionPackage}}.BuiltBy=goreleaser
-      - "-X '{{.Branchvals.VersionPackage}}.pk=LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF0YmZxNUtTYksyK2Z2Y1ozNlJ4dQpXSTJ1UnBHK25mb09zNldsaEJra3pZUTZNTlZpanJyMDh5ampadXRhU2NLMXN2YzJncitBdHUzUCtjOTJvdjBoCnIxQVVCZzd2WElwOTZFKzh3WDU4cld6cnNLa0JJKzBuTzBVbEtqeUFYelFpTnBCdkhEZEplbTVqbHRSeHJDYTAKd3kxOHJQbkpOdUx0WG15TjlGSEJXQ1o4YnZLOFJzaGFCSWJ1cUltK1FlT1k5RlZoS3MrWkFBeTBmMmpJNURNaAoxQ2FHQUhpN1RqR2NtNUpJTzFOZUszQWFNTUhuK2NLVVE4cG5ZOS92R2hPODZCQ2dzVzhjeXZ1d2JzT3pCM1I3CkRiangxbXFDVUtsUzl2Yzl2dHRxN0RtVWVqaWV3a0g2ZlZhUDZiU3AxcFJFMkFROHlGU0toc1VacU9KL0h4VWEKSWV5eDNoRmowcWh3ZjB2dm1XeHN3ZE4vdWd0VWRSZFRHdldyR0lZOWRpR0R5T3c3TkhBUnZEN2E5Tk1QT1IrTQpjSXJCdkNUT2ViWnAvNTh6Tlo5TUJZUFBQY05JNzUrZlk5TEExQk5Yd0ErZmZHaGlrMjJnVUg2djdsc3pVQWUrCnBWSGJZVU1mL2t1djJmNDVRWHdLRzJxSnFtZ3Nxdkw5eHd5OEJrWTc0dDltREdTTEhtV29YNTlUYjlzQ3ZqNmIKd3hnNU93R0RXSTJPNjhjTkVtYVpPd2QySGoxZ0pVOE1zbkhiUHF2SlhKNjVDYzRHTHBMSElQaGxrd0hkQlV0eApnK1dqbnoyVEdPT2wyaWhUMWVBM2pQUUFyejk4VFUwMjhYbE1xWEgzNE5hN3owb003dkF0VXpUbmwrOWNRSS85Cm45YUlqQVJYclNsNWd0azRVZkFDSURVQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo='"
-    goos:
-      - linux
-    goarch:
-      - amd64
-    binary: {{.Binary}}
-  {{- end}}
+  {{ end }} {{/* s390x */}}
 {{end}}

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -21,11 +21,18 @@
   {{- end }} {{/* el7 */}}
         include:
   {{- if has "el7" .Branchvals.Features }}
+            {{/* tyk-analytics(master branch) is supported on el7 by making a pure go build, all others inherit the same cgo value as set in the config. */}}
           - golang_cross: {{ if eq .Branch "release-5-lts"}}1.16-el7{{ else if eq .Branch "release-4-lts" }}1.15-el7{{ else if eq .Branch "master" }}{{ .Branchvals.Buildenv }}-pgo{{ end }}
             goreleaser: 'ci/goreleaser/goreleaser-el7.yml'
             rpmvers: 'el/7 amazon/2'
             debvers: 'ubuntu/xenial ubuntu/bionic debian/jessie'
+            {{- if and ( eq .Name "tyk-analytics" ) ( eq .Branch "master" ) }}
             cgo: 0
+            {{- else if .Branchvals.Cgo }}
+            cgo: 1
+            {{- else }}
+            cgo: 0
+            {{- end }}
   {{- end }} {{/* el7 */}}
           - golang_cross: {{ .Branchvals.Buildenv }}
             goreleaser: 'ci/goreleaser/goreleaser.yml'

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -11,24 +11,19 @@
         golang_cross:
           - {{ .Branchvals.Buildenv }}
   {{- if has "el7" .Branchvals.Features }}
-          {{ if eq .Branch "release-5-lts" -}}
+          {{ if or (eq .Branch "release-5-lts") (eq .Branch "release-4-lts") -}}
           - 1.16-el7
-          {{ else if eq .Branch "release-4-lts" -}}
-          - 1.15-el7
-          {{ else if eq .Branch "master" -}}
+          {{ else  -}}
           - {{ .Branchvals.Buildenv }}-pgo
           {{- end -}}
   {{- end }} {{/* el7 */}}
         include:
   {{- if has "el7" .Branchvals.Features }}
-            {{/* tyk-analytics(master branch) is supported on el7 by making a pure go build, all others inherit the same cgo value as set in the config. */}}
-          - golang_cross: {{ if eq .Branch "release-5-lts"}}1.16-el7{{ else if eq .Branch "release-4-lts" }}1.15-el7{{ else if eq .Branch "master" }}{{ .Branchvals.Buildenv }}-pgo{{ end }}
+          - golang_cross: {{ if or (eq .Branch "release-5-lts") ( eq .Branch "release-4-lts" ) }}1.16-el7{{ else }}{{ .Branchvals.Buildenv }}-pgo{{ end }}
             goreleaser: 'ci/goreleaser/goreleaser-el7.yml'
             rpmvers: 'el/7 amazon/2'
             debvers: 'ubuntu/xenial ubuntu/bionic debian/jessie'
-            {{- if and ( eq .Name "tyk-analytics" ) ( eq .Branch "master" ) }}
-            cgo: 0
-            {{- else if .Branchvals.Cgo }}
+            {{- if or (eq .Branch "release-5-lts") (eq .Branch "release-4-lts") }}
             cgo: 1
             {{- else }}
             cgo: 0

--- a/policy/templates/releng/ci/Dockerfile.std
+++ b/policy/templates/releng/ci/Dockerfile.std
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get dist-upgrade -y ca-certificates
 
-{{- if and (eq .Name "tyk") (eq .Branch "release-5-lts") }}
+{{- if has "python-support" .Branchvals.Features }}
 # For Python plugins
 RUN apt-get install -y python3-setuptools libpython3-dev python3-dev python3-grpcio
 {{- end }}
@@ -21,9 +21,7 @@ RUN rm -fv /usr/bin/passwd /usr/sbin/adduser || true
 RUN rm -rf /root/.cache \
     && apt-get -y autoremove \
     && apt-get clean \
-{{- if and (eq .Name "tyk") (eq .Branch "release-5-lts") }}
-    && rm -rf /usr/include/* \
-{{- end }}
+    && rm -rf /usr/include/* /var/cache/apt/archives /var/lib/{apt,dpkg,cache,log} \
     && find /usr/lib -type f -name '*.a' -o -name '*.o' -delete
 
 # Comment this to test in dev


### PR DESCRIPTION
- It appears gateway doesn't need separate el7 conditionals at all - so adds the el7 feature only to dashboard, and change the conditionals accordingly.

- s390x feature conditions were not set for the goreleaser.el7 templates, fixes it as well.

- Adds a new feature python-support to conditionally manage python plugin support in gateway 