### PR TITLE
Add the missing ui tests in templates

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/auto-test.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/auto-test.gotmpl
@@ -70,7 +70,8 @@
           - db: postgres15
             markers: "and not sql"   
         exclude: {{`${{ fromJson(needs.test-controller-ui.outputs.exclude) }}`}}
-{{ end }} {{/* End of ui-tests specific block */}}
+  {{- template "ui-tests" . }}
+  {{ end }} {{/* End of ui-tests specific block */}}
 
   api-tests:
     needs: [goreleaser, test-controller-api]


### PR DESCRIPTION
Including ui sub template in the auto test template was inadvertently removed earlier in a previous PR.
This fixes it.