### PR TITLE
[SYSE-369] Fix bundle render test

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,16 +21,16 @@ policy:
     - ci/Dockerfile.slim
     - ci/aws
     - ci/image
-  # Groups collect repos that have some common feature 
+  # Groups collect repos that have some common feature
   groups:
     # cgo-services contains the metadata required to manage repos that
     # are services and require cgo
     cgo-services:
       # features act as flags whose presence/absence can be used to render
-      # a common set of features across branch(es) 
-      # For eg: all regular builds now support el/7 by default, 
+      # a common set of features across branch(es)
+      # For eg: all regular builds now support el/7 by default,
       # but in order to build the pure go version of dashboard which can run on el7
-      # we make use of the `el7-pgo-build` feature flag to write the template conditions 
+      # we make use of the `el7-pgo-build` feature flag to write the template conditions
       # accordingly to it
       features:
         - releng
@@ -218,14 +218,8 @@ policy:
           branches:
             master:
     stand-alone-services:
-      buildenv: na
-      baseimage: na
-      distrolessbaseimage: na
       repos:
         tyk-ci:
-          binary: na
-          packagename: na
-          upgradefromver: 1.0.0
           description: >-
             Tyk automation repo environment for regression testing
           tests: [api,ui]
@@ -234,8 +228,6 @@ policy:
           branches:
             master:
         tyk-automated-tests:
-          binary: na
-          packagename: na
           upgradefromver: 1.0.0
           description: >-
             Tyk automation API tests repo for regression testing
@@ -243,4 +235,4 @@ policy:
           features:
             - test-square-tyk-api
           branches:
-            master:            
+            master:

--- a/policy/bundle_test.go
+++ b/policy/bundle_test.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -13,29 +14,38 @@ import (
 // repos in the config file.
 // FIXME: Test (bundle, features, repo) in parallel
 func TestBundleRender(t *testing.T) {
-	featDirs, err := templates.ReadDir("templates")
-	if err != nil {
-		t.Fatalf("Error reading embedded fs: %v", err)
-	}
-	var features []string
-	for _, fd := range featDirs {
-		if fd.IsDir() && fd.Name() != "subtemplates" {
-			features = append(features, fd.Name())
-		}
-	}
 	var pol Policies
 	config.LoadConfig("")
-	err = LoadRepoPolicies(&pol)
+	err := LoadRepoPolicies(&pol)
 	if err != nil {
 		t.Fatalf("Unable to load repo policies: %v", err)
 	}
-	b, err := NewBundle(features)
-	if err != nil {
-		t.Logf("Unable to create bundle obj: %v", err)
+
+	// Iterate through each group->repo->branch  and get the exhaustive list of  features
+	// used by each group
+	groupFeatures := make(map[string][]string)
+	for g, group := range pol.Groups {
+		var features []string
+		features = append(features, group.Features...)
+		for _, repo := range group.Repos {
+			features = append(features, repo.Features...)
+			for _, branch := range repo.Branches {
+				features = append(features, branch.Features...)
+
+			}
+		}
+		slices.Sort(features)
+		groupFeatures[g] = slices.Compact(features)
+		t.Logf("all features used by group %s : %v", g, groupFeatures[g])
 	}
+
 	for grpName, grp := range pol.Groups {
+		b, err := NewBundle(groupFeatures[grpName])
+		if err != nil {
+			t.Logf("Unable to create bundle obj: %v", err)
+		}
 		for r := range grp.Repos {
-			t.Logf("testing repo %s from group %s with features %v", r, grpName, features)
+			t.Logf("testing repo %s from group %s with features %v", r, grpName, groupFeatures[grpName])
 			rp, err := pol.GetRepoPolicy(r)
 			if err != nil {
 				t.Logf("Error getting repo policy for repo: %s: %v", r, err)


### PR DESCRIPTION
Instead of testing for all features in the templates dir, this change collects all the features used in a group and does the render test group-wise.
This also tests features that doesn't have a corresponding directory associated with it.