### PR TITLE
Fix release-5-lts goreleaser build

### DIFF
--- a/policy/templates/el7-pgo-build/ci/goreleaser/goreleaser-el7.yml
+++ b/policy/templates/el7-pgo-build/ci/goreleaser/goreleaser-el7.yml
@@ -4,8 +4,6 @@
 # - arm64
 # - amd64
 
-version: 2
-
 {{- if has "el7-pgo-build" .Branchvals.Features }}
   {{- template "cgo_builds" . }}
 {{- else }}

--- a/policy/templates/releng/ci/goreleaser/goreleaser.yml
+++ b/policy/templates/releng/ci/goreleaser/goreleaser.yml
@@ -5,7 +5,9 @@
 # - arm64
 # - amd64
 
+{{- if ne .Branchvals.Buildenv "1.16" }}
 version: 2
+{{- end }}
 
 {{- if eq .Name "portal"}}
 before:

--- a/policy/templates/subtemplates/goreleaser.yml.d/cgo_builds.gotmpl
+++ b/policy/templates/subtemplates/goreleaser.yml.d/cgo_builds.gotmpl
@@ -5,12 +5,10 @@ builds:
   - id: {{ $b }}
     flags:
       - -tags=ignore
-  {{- if not (has "plugin-compiler-fix-vendor" $r.Branchvals.Features) }}
       - -trimpath
       - -tags=goplugin
-  {{- end}} {{/* tyk */}}
   {{ if eq $b "fips" }}
-      - -tags=goplugin,fips,boringcrypto
+      - -tags=fips,boringcrypto
     env:
       - GOEXPERIMENT=boringcrypto
   {{- end }} {{/* fips */}}
@@ -29,10 +27,8 @@ builds:
   - id: std-arm64
     flags:
       - -tags=ignore
-  {{- if not (has "plugin-compiler-fix-vendor" $r.Branchvals.Features) }}
       - -trimpath
       - -tags=goplugin
-  {{- end}} {{/* tyk */}}
     ldflags:
       - -X {{$r.Branchvals.VersionPackage}}.Version={{`{{.Version}}`}}
       - -X {{$r.Branchvals.VersionPackage }}.Commit={{`{{.FullCommit}}`}}
@@ -50,10 +46,8 @@ builds:
   - id: std-s390x
     flags:
       - -tags=ignore
-  {{- if not (has "plugin-compiler-fix-vendor" $r.Branchvals.Features) }}
       - -trimpath
       - -tags=goplugin
-  {{- end}} {{/* tyk */}}
     ldflags:
       - -X {{$r.Branchvals.VersionPackage}}.Version={{`{{.Version}}`}}
       - -X {{$r.Branchvals.VersionPackage}}.Commit={{`{{.FullCommit}}`}}


### PR DESCRIPTION
- Removes version for goreleaser over 1.16 builds
- Include tags 'goplugin' and 'trim' for all builds