### PR TITLE
TT-12815,  upgrade to golang 1.22

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,7 +40,7 @@ policy:
       # The build environment used for this repo. Right now, this value
       # is used for selecting the appropriate golang-cross image
       # used for building the binary, packages and docker images.
-      buildenv: 1.22-bookworm
+      buildenv: 1.22-bullseye
       # baseimage what the container images are based on. It needs to be a
       # debian compatible distro as the Dockerfile assumes apt-get
       baseimage: debian:bookworm-slim
@@ -102,6 +102,7 @@ policy:
                 - release-test
                 - distroless
             release-5.3:
+              buildenv: 1.22-bullseye
               features:
                 - distroless
                 - s390x
@@ -142,6 +143,7 @@ policy:
                 - s390x
                 - distroless
             release-5.3:
+              buildenv: 1.22-bullseye
               features:
                 - distroless
                 - s390x

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -40,7 +40,7 @@ policy:
       # The build environment used for this repo. Right now, this value
       # is used for selecting the appropriate golang-cross image
       # used for building the binary, packages and docker images.
-      buildenv: 1.21-bullseye
+      buildenv: 1.22-bookworm
       # baseimage what the container images are based on. It needs to be a
       # debian compatible distro as the Dockerfile assumes apt-get
       baseimage: debian:bookworm-slim

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -235,6 +235,7 @@
 
       - name: save deb
         uses: actions/upload-artifact@v4
+        if: {{`${{ matrix.golang_cross == '` }}{{.Branchvals.Buildenv}}{{`' }}`}}
         with:
           name: deb
           retention-days: 1
@@ -245,6 +246,7 @@
 
       - name: save rpm
         uses: actions/upload-artifact@v4
+        if: {{`${{ matrix.golang_cross == '` }}{{.Branchvals.Buildenv}}{{`' }}`}}
         with:
           name: rpm
           retention-days: 1

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -235,7 +235,6 @@
 
       - name: save deb
         uses: actions/upload-artifact@v4
-        if: {{`${{ matrix.golang_cross == '` }}{{.Branchvals.Buildenv}}{{`' }}`}}
         with:
           name: deb
           retention-days: 1
@@ -246,7 +245,6 @@
 
       - name: save rpm
         uses: actions/upload-artifact@v4
-        if: {{`${{ matrix.golang_cross == '` }}{{.Branchvals.Buildenv}}{{`' }}`}}
         with:
           name: rpm
           retention-days: 1


### PR DESCRIPTION
changed buildenv  for cgo-services from "buildenv: 1.21-bullseye" to "buildenv: 1.22-bookworm"