### PR TITLE
Add concurrency limit for workflows

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml
+++ b/policy/templates/releng/.github/workflows/release.yml
@@ -20,7 +20,10 @@ on:
       - release-**
     tags:
       - 'v*'
-
+concurrency:
+  group: {{`${{ github.workflow }}-${{ github.ref }}`}}
+  cancel-in-progress: true
+  
 env:
   GOPRIVATE: github.com/TykTechnologies
   VARIATION: prod

--- a/policy/templates/test-square/.github/workflows/test-square.yml
+++ b/policy/templates/test-square/.github/workflows/test-square.yml
@@ -21,11 +21,12 @@ on:
       - 'tests/ui/**'
       - 'tests/api/**'
 {{- end }}
-
+concurrency:
+  group: {{`${{ github.workflow }}-${{ github.ref }}`}}
+  cancel-in-progress: true
 env:
   VARIATION: prod
   BASE_REF: {{`${{startsWith(github.event_name, 'pull_request') && github.base_ref || github.ref_name}}`}}
-
 jobs:
 {{- $DOT := . }}
 {{- range $test := .Branchvals.Tests }}


### PR DESCRIPTION
This prevents multiple workflows running after commit if previous are still running, this reduces the cost increase in runners billiable time