### PR TITLE
SYSE-396/Fix metadata report ui test step

### DIFF
--- a/policy/templates/subtemplates/auto/auto-test.gotmpl
+++ b/policy/templates/subtemplates/auto/auto-test.gotmpl
@@ -193,6 +193,7 @@
           git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"                    
       - name: Execute UI tests
         working-directory: tyk-analytics/tests/{{ .test }}
+        id: test_execution
         env:
           GW_URL: 'https://localhost:8080/'
           NODE_TLS_REJECT_UNAUTHORIZED: 0


### PR DESCRIPTION
Missing reference on execution step is preventing metadata generation step to run