### PR TITLE
invert tui config file to reduce repetition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ REPOS        ?= tyk tyk-analytics tyk-pump tyk-identity-broker tyk-sink portal t
 GITHUB_TOKEN ?= $(shell pass me/github)
 JIRA_USER    ?= alok@tyk.io
 JIRA_TOKEN   ?= $(shell pass Tyk/atlassian)
+VARIATION    ?= inverted
 
-gromit: go.mod go.sum *.go $(SRC) $(TEMPLATES)
+gromit: go.mod go.sum *.go $(SRC) $(TEMPLATES) update-variation
 	go build -v -trimpath -ldflags "-X github.com/TykTechnologies/gromit/util.version=$(VERSION) -X github.com/TykTechnologies/gromit/util.commit=$(COMMIT) -X github.com/TykTechnologies/gromit/util.buildDate=$(BUILD_DATE)"
 	go mod tidy
 
@@ -34,7 +35,10 @@ update-test-cases:
 	go test ./cmd/ -update
 
 update-actions-versions: bin/update-actions-versions.sed
-	echo $(TEMPLATES) | xargs sed -i -f $^
+	echo $(TEMPLATES) | xargs sed -i -f $<
+
+update-variation: policy/templates/test-square/.github/workflows/test-square.yml policy/templates/releng/.github/workflows/release.yml
+	sed -i 's/VARIATION: .*/VARIATION: $(VARIATION)/' $^
 
 push: dist/gromit_linux_amd64_v1/gromit
 	goreleaser --clean --snapshot

--- a/policy/app/index.html
+++ b/policy/app/index.html
@@ -9,71 +9,71 @@
   </head>
   <body>
     <h1>Available variations</h2>
-    {{ range $fname, $variations := .AllVariations }}
-       <h2> {{ $fname }}</h2>
-       <div id="repos" class="repo-carousel">
-	 {{ range $repoName, $repo := $variations }}
-	 <div class="repo-carousel-item">
-	   <h3>{{ $repoName }}</h3>
-	   {{ range $b := $repo.Branches }}
-	   {{ range $tr := $repo.Triggers $b }}
-	   {{ range $ts := $repo.Testsuites $b $tr }}
-	   {{ $matrix := $repo.Lookup $b $tr $ts }}
-	   <p>
-	     On {{ $tr }} to {{ $b }}, {{ $ts }} testsuite will run with
-	     <ul>
-	       <li>Environment files</li>
-	       <ul>
-	       {{range $ef := $matrix.EnvFiles}}
-		 <li> {{ $ef }}</li>
-	       {{ end }}
-	       </ul>
-	       <li>Distros</li>
-	       <ul>
-				   <li>Rpm</li>
-					 <ul>
-	         {{range $rpm := $matrix.Distros.Rpm}}
-					 <li> {{ $rpm }}</li>
-	         {{ end }}
-					 </ul>
-				   <li>Deb</li>
-					 <ul>
-	         {{range $deb := $matrix.Distros.Deb}}
-					 <li> {{ $deb }}</li>
-	         {{ end }}
-					 </ul>
-				</ul>					 							 
-	       {{ if ne $repoName "tyk-pump" }}
-	       <li>Pump versions</li>
-	       <ul>
-	       {{range $ef := $matrix.Pump}}
-		 <li> {{ $ef }}</li>
-	       {{ end }}
-	       </ul>
-	       {{ end }} {{/* if not pump */}}
-	       {{ if ne $repoName "tyk-sink" }}
-	       <li>Sink versions</li>
-	       <ul>
-	       {{range $ef := $matrix.Sink}}
-		 <li> {{ $ef }}</li>
-	       {{ end }}
-	       </ul>
-	       {{ end }} {{/* if not sink */}}
-	     </ul>
-	   </p>
-	   {{ end }} {{/* testsuites */}}
-	   {{ end }} {{/* triggers */}}
-	   {{ end }} {{/* branches */}}
-	 </div>
-	 {{ end }} {{/* repos */}}
-       </div>
-       <hr>
-  {{ end }} {{/* AllVariations */}}
-    <h1>Files in {{ .SaveDir }} </h1>
-    <ul class="saved-grid">
-      {{ range $file := .AllVariations.Files }}
-      <li><a href="/show/{{ $file }}" target="_blank" rel="noopener noreferrer">{{ $file }}</a></li>
-      {{end}}
-    </ul>
-  </body>
+{{ range $fname, $variations := .AllVariations }}
+<h2> {{ $fname }}</h2>
+<div id="repos" class="repo-carousel">
+  {{ range $r := $variations.Repos }}
+  <div class="repo-carousel-item">
+    <h3>{{ $r }}</h3>
+    {{ range $b := $variations.Branches $r }}
+    {{ range $tr := $variations.Triggers $r $b }}
+    {{ range $ts := $variations.Testsuites $r $b $tr }}
+    {{ $matrix := $variations.Lookup $r $b $tr $ts }}
+    <p>
+      On {{ $tr }} to {{ $b }}, {{ $ts }} testsuite will run with
+      <ul>
+	<li>Environment files</li>
+	<ul>
+	  {{range $ef := $matrix.EnvFiles}}
+	  <li> {{ $ef }}</li>
+	  {{ end }}
+	</ul>
+	<li>Distros</li>
+	<ul>
+	  <li>Rpm</li>
+	  <ul>
+	    {{range $rpm := $matrix.Distros.Rpm}}
+	    <li> {{ $rpm }}</li>
+	    {{ end }}
+	  </ul>
+	  <li>Deb</li>
+	  <ul>
+	    {{range $deb := $matrix.Distros.Deb}}
+	    <li> {{ $deb }}</li>
+	    {{ end }}
+	  </ul>
+	</ul>
+	{{ if ne $r "tyk-pump" }}
+	<li>Pump versions</li>
+	<ul>
+	  {{range $ef := $matrix.Pump}}
+	  <li> {{ $ef }}</li>
+	  {{ end }}
+	</ul>
+	{{ end }} {{/* if not pump */}}
+	{{ if ne $r "tyk-sink" }}
+	<li>Sink versions</li>
+	<ul>
+	  {{range $ef := $matrix.Sink}}
+	  <li> {{ $ef }}</li>
+	  {{ end }}
+	</ul>
+	{{ end }} {{/* if not sink */}}
+      </ul>
+    </p>
+    {{ end }} {{/* testsuites */}}
+    {{ end }} {{/* triggers */}}
+    {{ end }} {{/* branches */}}
+  </div>
+  {{ end }} {{/* repos */}}
+</div>
+<hr>
+{{ end }} {{/* AllVariations */}}
+<h1>Files in {{ .SaveDir }} </h1>
+<ul class="saved-grid">
+  {{ range $file := .AllVariations.Files }}
+  <li><a href="/show/{{ $file }}" target="_blank" rel="noopener noreferrer">{{ $file }}</a></li>
+  {{end}}
+</ul>
+</body>
 </html>

--- a/policy/templates/releng/.github/workflows/release.yml
+++ b/policy/templates/releng/.github/workflows/release.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   GOPRIVATE: github.com/TykTechnologies
-  VARIATION: prod
+  VARIATION: inverted
   DOCKER_BUILD_SUMMARY: false
   DOCKER_BUILD_RECORD_UPLOAD: false
   # startsWith covers pull_request_target too

--- a/policy/templates/test-square/.github/workflows/test-square.yml
+++ b/policy/templates/test-square/.github/workflows/test-square.yml
@@ -23,7 +23,7 @@ on:
 {{- end }}
 
 env:
-  VARIATION: prod
+  VARIATION: inverted
   BASE_REF: {{`${{startsWith(github.event_name, 'pull_request') && github.base_ref || github.ref_name}}`}}
 
 jobs:

--- a/policy/tui_test.go
+++ b/policy/tui_test.go
@@ -59,21 +59,21 @@ func TestV1Variations(t *testing.T) {
 		{
 			Name:         "EnvFiles",
 			Endpoint:     "/api/repo1/br0/tr0/ts0/EnvFiles",
-			ResponseJSON: `[{"cache":"repo1-redis0", "config":"repo1-conf0", "db":"repo1-db0", "apimarkers":"", "uimarkers":""}]`,
+			ResponseJSON: `[{"cache":"redis0", "config":"conf0", "db":"db0", "apimarkers":"am0", "uimarkers":"um0"}]`,
 			HTTPStatus:   http.StatusOK,
 			HTTPMethod:   "GET",
 		},
 		{
 			Name:         "Pump",
-			Endpoint:     "/api/repo0/br1/tr1/ts0/Pump",
+			Endpoint:     "/api/repo0/br1/tr1/ts1/Pump",
 			ResponseJSON: `["pump-br1", "master"]`,
 			HTTPStatus:   http.StatusOK,
 			HTTPMethod:   "GET",
 		},
 		{
 			Name:         "Sink",
-			Endpoint:     "/api/repo1/br0/tr1/ts0/Sink",
-			ResponseJSON: `["sink-br0", "master"]`,
+			Endpoint:     "/api/repo0/unknown/tr0/ts0/Sink",
+			ResponseJSON: `["master"]`,
 			HTTPStatus:   http.StatusOK,
 			HTTPMethod:   "GET",
 		},
@@ -87,15 +87,15 @@ func TestV2Variations(t *testing.T) {
 		{
 			Name:         "EnvFiles",
 			Endpoint:     "/v2/prod-variations/repo0/br0/tr0/ts0/EnvFiles.json",
-			ResponseJSON: `[{"cache":"repo0-redis0", "config":"repo0-conf0", "db":"", "apimarkers":"m0", "uimarkers":"m1"}]`,
+			ResponseJSON: `[{"cache":"redis0", "config":"conf0", "db":"db0", "apimarkers":"am0", "uimarkers":"um0"}]`,
 			HTTPStatus:   http.StatusOK,
 			HTTPMethod:   "GET",
 		},
 		{
 			Name:     "gho",
-			Endpoint: "/v2/prod-var/repo0/br1/tr1/ts0.gho",
+			Endpoint: "/v2/prod-var/repo0/br1/tr1/ts1.gho",
 			ResponseText: `envfiles<<EOF
-[{"cache":"repo0-redis-tr1","db":"","config":"repo0-conf-tr1","apimarkers":"","uimarkers":""},{"cache":"repo0-redis0","db":"","config":"repo0-conf0","apimarkers":"m0","uimarkers":"m1"}]
+[{"cache":"redis-br1","db":"db-br1","config":"conf-br1","apimarkers":"br1-am1","uimarkers":"br1-um1"},{"cache":"redis1","db":"db1","config":"conf1","apimarkers":"am1","uimarkers":"um1"},{"cache":"redis0","db":"db0","config":"conf0","apimarkers":"am0","uimarkers":"um0"}]
 EOF
 pump<<EOF
 ["pump-br1","master"]
@@ -112,7 +112,7 @@ EOF
 		},
 		{
 			Name:     "field-gho",
-			Endpoint: "/v2/prod-variations.yml/repo0/br1/tr1/ts0/Distros.gho",
+			Endpoint: "/v2/prod-variations.yml/repo1/unknown/tr0/ts0/Distros.gho",
 			ResponseText: `deb<<EOF
 ["d1"]
 EOF

--- a/testdata/tui/prod-variations.yml
+++ b/testdata/tui/prod-variations.yml
@@ -1,54 +1,58 @@
+envfiles:
+  - cache: redis0
+    config: conf0
+    db: db0
+    apimarkers: am0
+    uimarkers: um0
 pump:
   - master
 sink:
   - master
-level: # repos
-  repo0:
-    envfiles:
-      - cache: repo0-redis0
-        config: repo0-conf0
-        apimarkers: m0
-        uimarkers: m1
-    level: # branches
-      br0:
-        pump: [pump-br0]
-        sink: [sink-br0]
+distros:
+  deb:
+    - d1
+  rpm:
+    - d0
+level: # testsuites
+  ts0:
+    level: # branch
+      master:
         level: # trigger
           tr0:
-            level: # testsuite
-              ts0:
-              ts1:
+            level: # repo
+              repo0:
+              repo1:
       br1:
-        pump: [pump-br1]
-        sink: [sink-br1]
+        pump:
+          - pump-br1
+        sink:
+          - sink-br1
         level: # trigger
           tr1:
-            distros:
-              rpm:
-                - d0
-              deb:
-                - d1
-            envfiles:
-              - cache: repo0-redis-tr1
-                config: repo0-conf-tr1
-            level: # testsuite
-              ts0:
-              ts1:
-  repo1:
+            level: # repo
+              repo0:
+              repo1:
+  ts1:
     envfiles:
-      - cache: repo1-redis0
-        db: repo1-db0
-        config: repo1-conf0
-    level: # branches
-      br0:
-        pump: [pump-br0]
-        sink: [sink-br0]
+      - cache: redis1
+        config: conf1
+        db: db1
+        apimarkers: am1
+        uimarkers: um1
+    level: # branch
+      br1:
+        envfiles:
+          - cache: redis-br1
+            config: conf-br1
+            db: db-br1
+            apimarkers: br1-am1
+            uimarkers: br1-um1
+        pump:
+          - pump-br1
+        sink:
+          - sink-br1
         level: # trigger
-          tr0:
-            level: # testsuite
-              ts0:
-              ts1:
           tr1:
-            level: # testsuite
-              ts0:
-              ts1:
+            level: # repo
+              repo0:
+              repo1:


### PR DESCRIPTION
There are 6+ repos and this might increase. We have only two test suites. Making the hierarchy of the tui config format testsuite→branch→trigger→repo reduces the amount of repetition.
The UI remains the same as does the API. However, the config format has changed and will need to be updated when this is merged to master. The tui config file that goes along with this PR is http://tui.internal.dev.tyk.technology/show/inverted.yml