### PR TITLE
[QA-1539] Make checkout test code to use proper branch/tag

### DIFF
--- a/policy/templates/subtemplates/auto/auto-test.gotmpl
+++ b/policy/templates/subtemplates/auto/auto-test.gotmpl
@@ -142,7 +142,9 @@
           ref: {{`${{ env.BASE_REF }}`}}
           {{- end }}
           {{- if eq .flow "nightly" }}
-          ref: {{`${{ matrix.envfiles.gwdash }}`}}
+            ref: {{`${{ matrix.envfiles.gwdash }}`}}
+          {{- else }}
+            ref: $BASE_REF
           {{- end }}
           sparse-checkout: tests/{{ .test }}
           

--- a/policy/templates/subtemplates/auto/auto-test.gotmpl
+++ b/policy/templates/subtemplates/auto/auto-test.gotmpl
@@ -142,9 +142,9 @@
           ref: {{`${{ env.BASE_REF }}`}}
           {{- end }}
           {{- if eq .flow "nightly" }}
-            ref: {{`${{ matrix.envfiles.gwdash }}`}}
+          ref: {{`${{ matrix.envfiles.gwdash }}`}}
           {{- else }}
-            ref: $BASE_REF
+          ref: $BASE_REF
           {{- end }}
           sparse-checkout: tests/{{ .test }}
           


### PR DESCRIPTION
Add using of $BASE_REF in checkout action. $BASE_REF is declared is defined at the top of template and seems to work fine with push/pull/tag event triggers