### PR TITLE
[TT-13027] dashboard: disable CGO, add release-test to master

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -134,7 +134,7 @@ policy:
           exposeports: "3000 5000"
           binary: tyk-analytics
           packagename: tyk-dashboard
-          cgo: true
+          cgo: false
           upgradefromver: 3.0.9
           configfile: tyk_analytics.conf
           deletedfiles:
@@ -151,11 +151,13 @@ policy:
                 - distroless
                 - s390x
                 - distroless
+                - release-test
             release-5.3:
               buildenv: 1.22-bullseye
               features:
                 - distroless
                 - s390x
+                - release-test
             release-5.5:
               features:
                 - distroless

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -134,7 +134,7 @@ policy:
           exposeports: "3000 5000"
           binary: tyk-analytics
           packagename: tyk-dashboard
-          cgo: false
+          cgo: true
           upgradefromver: 3.0.9
           configfile: tyk_analytics.conf
           deletedfiles:
@@ -146,6 +146,7 @@ policy:
             - api
           branches:
             master:
+              cgo: false
               features:
                 - nightly-e2e
                 - distroless


### PR DESCRIPTION
PR does the following:

- Disables CGO for analytics master (5.7), for https://github.com/TykTechnologies/tyk-analytics/pull/4187
- Adds release-tests to run release-test.yml

Intended for 5.7+

JIRA: https://tyktech.atlassian.net/browse/TT-13027

Status:

- [x] cgo: 0 verified in release.yml
- [x] added release-test snippet to release.yml in above PR
- [x] verify 5.7.0-alpha4

Other changes rendered with policy sync that have been excluded (fetch-depth, ref, some other playwright report related changes). Release 5.6 doesn't seem up to date.

Verified like so:

```
# docker create --name dash tykio/tyk-dashboard:v5.7.0-alpha4
00c04465199a65decbe35c851e98ac93482f93effe3b07634c38067121390204
# docker cp dash:/opt/tyk-dashboard/tyk-analytics .
Successfully copied 304MB to /root/tyk/tyk-analytics/.
# file tyk-analytics 
tyk-analytics: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=ZvM4eTnjYk1pZ0YB6Dwr/plXZoibAstfVmX-c8Xxo/NV2VflEy_SnIGsIw7nWt/mXi79XZm-O-GJ2UELuIa, with debug_info, not stripped
```