### PR TITLE
[TT-13385] Exclude -trimpath build flag from 5-lts and 4-lts builds

### DIFF
--- a/policy/templates/subtemplates/goreleaser.yml.d/cgo_builds.gotmpl
+++ b/policy/templates/subtemplates/goreleaser.yml.d/cgo_builds.gotmpl
@@ -18,7 +18,9 @@ builds:
   - id: {{ $b }}
     flags:
       - -tags=ignore
+      {{ if not (or (eq .Branch "release-5-lts") (eq .Branch "release-4-lts")) }}
       - -trimpath
+      {{ end }}
       - -tags=goplugin{{ if eq $b "fips" }},fips,boringcrypto{{ if $has_ee }},ee{{ end }}{{ else if eq $b "ee" }},ee{{ end }}
     {{ if eq $b "fips" }}
     env:
@@ -39,7 +41,9 @@ builds:
   - id: {{ $b }}-arm64
     flags:
       - -tags=ignore
+      {{ if not (or (eq .Branch "release-5-lts") (eq .Branch "release-4-lts")) }}
       - -trimpath
+      {{ end }}
       - -tags=goplugin{{ if eq $b "ee" }},ee{{ end }}
     ldflags:
       - -X {{$r.Branchvals.VersionPackage}}.Version={{`{{.Version}}`}}
@@ -58,7 +62,9 @@ builds:
   - id: {{ $b }}-s390x
     flags:
       - -tags=ignore
+      {{ if not (or (eq .Branch "release-5-lts") (eq .Branch "release-4-lts")) }}
       - -trimpath
+      {{ end }}
       - -tags=goplugin{{ if eq $b "ee" }},ee{{ end }}
     ldflags:
       - -X {{$r.Branchvals.VersionPackage}}.Version={{`{{.Version}}`}}


### PR DESCRIPTION
This PR excludes `-trimpath` build flag from 5-lts and 4-lts builds