### PR TITLE
[TT-13760] tyk_config_sample.config file has been renamed 

### DIFF
--- a/policy/templates/subtemplates/goreleaser.yml.d/archives.gotmpl
+++ b/policy/templates/subtemplates/goreleaser.yml.d/archives.gotmpl
@@ -17,7 +17,7 @@ archives:
       - portal/*
       - schemas/*
       - lang/*
-      - tyk_config_sample.config
+      - tyk-analytics.conf.example
     {{- end }}
     {{- if eq .Name "tyk" }}
       - "LICENSE.md"

--- a/policy/templates/subtemplates/goreleaser.yml.d/dockers.gotmpl
+++ b/policy/templates/subtemplates/goreleaser.yml.d/dockers.gotmpl
@@ -32,7 +32,7 @@ dockers:
       - "portal"
       - "schemas"
       - "webclient/lang"
-      - "tyk_config_sample.config"
+      - "tyk-analytics.conf.example"
       {{- end}}
 
       {{- if (eq $r.Name "tyk") }}

--- a/policy/templates/subtemplates/goreleaser.yml.d/nfpm.gotmpl
+++ b/policy/templates/subtemplates/goreleaser.yml.d/nfpm.gotmpl
@@ -58,7 +58,7 @@ nfpms:
           dst: "/opt/{{ $r.PackageName }}/schemas"
         - src: "webclient/lang/*"
           dst: "/opt/{{ $r.PackageName }}/lang"
-        - src: tyk_config_sample.config
+        - src: tyk-analytics.conf.example
           dst: /opt/{{ $r.PackageName }}/{{ $r.Branchvals.ConfigFile }}
           type: "config|noreplace"
     {{- end}}


### PR DESCRIPTION
In the context of [TT-13760](https://tyktech.atlassian.net/browse/TT-13760), `tyk_config_sample.config` file has been renamed to `tyk-analytics.conf.example` in tyk-analytics repository. This PR syncs gromit with tyk-analytics. 

Related PR: https://github.com/TykTechnologies/tyk-analytics/pull/4449

[TT-13760]: https://tyktech.atlassian.net/browse/TT-13760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ