### PR TITLE
[SYSE-403] docker image names from builds object

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -154,6 +154,7 @@ policy:
                   buildpackagename: tyk-gateway-ee
                   pcrepo: tyk-ee-unstable
                   dhrepo: tykio/tyk-gateway-ee
+                  csrepo: docker.tyk.io/tyk-gateway/tyk-gateway-ee
                   cirepo: tyk-ee
                   archs:
                     - go: amd64
@@ -189,6 +190,7 @@ policy:
                   buildpackagename: tyk-gateway-ee
                   pcrepo: tyk-ee-unstable
                   dhrepo: tykio/tyk-gateway-ee
+                  csrepo: docker.tyk.io/tyk-gateway/tyk-gateway-ee
                   cirepo: tyk-ee
                   archs:
                     - go: amd64

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -148,6 +148,7 @@ policy:
                 ee:
                   flags:
                     - -tags=goplugin,ee
+                    - -trimpath
                   description: >-
                     Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols
                   imagetitle: Tyk Gateway Enterprise Edition
@@ -184,6 +185,7 @@ policy:
                 ee:
                   flags:
                     - -tags=goplugin,ee
+                    - -trimpath
                   description: >-
                     Tyk API Gateway Enterprise Edition written in Go, supporting REST, GraphQL, TCP and gRPC protocols
                   imagetitle: Tyk Gateway Enterprise Edition

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -61,6 +61,7 @@ func TestPolicyConfig(t *testing.T) {
 			{"doc1", "deb1", "go1"},
 			{"doc2", "deb2", "go2"}},
 	}, *repo1.Branchvals.Builds["std"], "testing full merge")
-	assert.EqualValues(t, []string{"repo1-doc-right"}, repo1.GetImages("DHRepo"), "testing getImages()")
-	assert.EqualValues(t, []string{"doc1", "doc2"}, repo1.GetDockerPlatforms(), "testing getDockerPlatforms()")
+	build := repo1.Branchvals.Builds["std"]
+	assert.EqualValues(t, []string{"repo1-doc-right"}, build.GetImages("DHRepo"), "testing getImages()")
+	assert.EqualValues(t, []string{"doc1", "doc2"}, build.GetDockerPlatforms(), "testing getDockerPlatforms()")
 }

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -183,7 +183,7 @@
         uses: docker/build-push-action@v6
         with:
           context: "dist"
-          platforms: {{ $r.GetDockerPlatforms | join "," }}
+          platforms: {{ $bv.GetDockerPlatforms | join "," }}
           {{- if has "distroless" $r.Branchvals.Features }}
           file: ci/Dockerfile.distroless
           {{- else }}
@@ -199,14 +199,14 @@
           build-args: |
             BUILD_PACKAGE_NAME={{ $bv.BuildPackageName }}
 
-      - name: Docker metadata for tag push
+      - name: Docker metadata for {{ $b }} tag push
         id: tag_metadata_{{ $b }}
         uses: docker/metadata-action@v5
         with:
           images: |
-          {{- range $image :=  $r.GetImages "DHRepo" "CSRepo" }}
+          {{- range $image :=  $bv.GetImages "DHRepo" "CSRepo" }}
             {{ $image }}
-          {{end}}
+          {{- end}}
           flavor: |
             latest=false
             prefix=v
@@ -224,12 +224,12 @@
         uses: docker/build-push-action@v6
         with:
           context: "dist"
-          platforms: {{ $r.GetDockerPlatforms | join "," }}
+          platforms: {{ $bv.GetDockerPlatforms | join "," }}
           {{- if has "distroless" $r.Branchvals.Features }}
           file: ci/Dockerfile.distroless
           {{- else }}
           file: ci/Dockerfile.std
-          {{ end }}
+          {{- end }}
           provenance: mode=max
           sbom: true
           cache-from: type=gha

--- a/policy/tfuncs.go
+++ b/policy/tfuncs.go
@@ -17,27 +17,23 @@ func (rp RepoPolicy) GetCC(target, host string) string {
 }
 
 // getImages returns the list of container manifests
-func (rp RepoPolicy) GetImages(repos ...string) []string {
+func (b *build) GetImages(repos ...string) []string {
 	images := make(util.Set[string])
-	for _, bv := range rp.Branchvals.Builds {
-		for _, repo := range repos {
-			image := getBuildField(bv, repo)
-			if len(image) > 0 {
-				images.Add(image)
-			}
+	for _, repo := range repos {
+		image := getBuildField(b, repo)
+		if len(image) > 0 {
+			images.Add(image)
 		}
 	}
 	return images.Members()
 }
 
 // getDockerPlatforms returns the list of docker platforms that are to be supported
-func (rp RepoPolicy) GetDockerPlatforms() []string {
+func (b *build) GetDockerPlatforms() []string {
 	platforms := make(util.Set[string])
-	for _, bv := range rp.Branchvals.Builds {
-		for _, a := range bv.Archs {
-			if len(a.Docker) > 0 {
-				platforms.Add(a.Docker)
-			}
+	for _, a := range b.Archs {
+		if len(a.Docker) > 0 {
+			platforms.Add(a.Docker)
 		}
 	}
 	return platforms.Members()


### PR DESCRIPTION
Previously, the `GetImages` template function was on the RepoPolicy object and would iterate over the builds to find the image names. This is a bug because we need the image names for a build, not just any image names.

This was addressed by making the GetImages a method of the `build` object. A similar change was made for `GetDockerPlatforms`.