### PR TITLE
[TT-15334/docker fips] Add docker images with fips binaries

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -101,9 +101,12 @@ policy:
                 - -tags=goplugin,fips,boringcrypto
               buildpackagename: tyk-gateway-fips
               pcrepo: tyk-ee-unstable
+              dhrepo: tykio/tyk-gateway-fips
+              cirepo: tyk-fips
               description: >-
                 Tyk Open Source API Gateway written in Go, supporting REST, GraphQL, TCP and gRPC protocols
                 Built with boringssl
+              imagetitle: Tyk Gateway FIPS
               archs:
                 - go: amd64
                   deb: amd64
@@ -253,8 +256,11 @@ policy:
               description: >-
                 Dashboard for the Tyk API Gateway.
                 This version is compiled with boringssl.
+              imagetitle: Tyk Dashboard FIPS
               buildpackagename: tyk-dashboard-fips
               pcrepo: tyk-ee-unstable
+              dhrepo: tykio/tyk-dashboard-fips
+              cirepo: tyk-analytics-fips
               archs:
                 - go: amd64
                   deb: amd64
@@ -362,9 +368,12 @@ policy:
                 - -tags=fips,boringcrypto
               buildpackagename: tyk-pump-fips
               pcrepo: tyk-ee-unstable
+              dhrepo: tykio/tyk-pump-fips
+              cirepo: tyk-pump-fips
               description: >-
                 Tyk Analytics Pump to move analytics data from Redis to any supported back end (multiple back ends can be written to at once).
                 This version is compiled with boringssl.
+              imagetitle: Tyk Analytics Pump FIPS
               archs:
                 - go: amd64
                   deb: amd64
@@ -441,6 +450,8 @@ policy:
                 - -tags=fips,boringcrypto
               buildpackagename: tyk-sink-fips
               pcrepo: tyk-ee-unstable
+              dhrepo: tykio/tyk-mdcb-fips
+              cirepo: tyk-sink-fips
               description: >-
                 Tyk RPC server backend (bridge)
                 This version is compiled with boringssl.

--- a/policy/templates/releng/ci/goreleaser/goreleaser.yml
+++ b/policy/templates/releng/ci/goreleaser/goreleaser.yml
@@ -16,6 +16,10 @@ before:
 
 {{- template "builds" . }}
 
+{{- template "dockers" . }}
+
+{{- template "docker_manifests" . }}
+
 # This disables archives
 archives:
   - formats: [ 'binary' ]

--- a/policy/templates/subtemplates/goreleaser.yml.d/docker_manifests.gotmpl
+++ b/policy/templates/subtemplates/goreleaser.yml.d/docker_manifests.gotmpl
@@ -1,27 +1,66 @@
 {{ define "docker_manifests" }}
 docker_manifests:
-  - name_template: {{ .DHRepo }}:{{`{{ .Tag }}`}}
+  {{- $r := . }}
+  {{- range $b, $bv := .Branchvals.Builds }}
+  {{- $amd64_exists := false }}
+  {{- $arm64_exists := false }}
+  {{- range $a := $bv.Archs }}
+    {{- if eq $a.Go "amd64" }}{{ $amd64_exists = true }}{{ end }}
+    {{- if eq $a.Go "arm64" }}{{ $arm64_exists = true }}{{ end }}
+  {{- end }}
+  {{- if and $amd64_exists $arm64_exists }}
+  - name_template: {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}{{ if ne $b "std" }}-{{ $b }}{{ end }}
     image_templates:
-      - {{ .DHRepo }}:{{`{{ .Tag }}`}}-amd64
-      - {{ .DHRepo }}:{{`{{ .Tag }}`}}-arm64
-  - name_template: {{ .DHRepo }}:v{{`{{ .Major }}.{{ .Minor }}{{.Prerelease}}`}}
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}amd64
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}arm64
+  - name_template: {{ $bv.DHRepo }}:v{{`{{ .Major }}.{{ .Minor }}{{.Prerelease}}`}}{{ if ne $b "std" }}-{{ $b }}{{ end }}
     image_templates:
-      - {{ .DHRepo }}:{{`{{ .Tag }}`}}-amd64
-      - {{ .DHRepo }}:{{`{{ .Tag }}`}}-arm64
-  - name_template: {{ .DHRepo }}:v{{`{{ .Major }}{{.Prerelease}}`}}
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}amd64
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}arm64
+  - name_template: {{ $bv.DHRepo }}:v{{`{{ .Major }}{{.Prerelease}}`}}{{ if ne $b "std" }}-{{ $b }}{{ end }}
     image_templates:
-      - {{ .DHRepo }}:{{`{{ .Tag }}`}}-amd64
-      - {{ .DHRepo }}:{{`{{ .Tag }}`}}-arm64
-  {{- if eq .Name "tyk" }}
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}amd64
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}arm64
+  {{- if $bv.CSRepo }}
+  - name_template: {{ $bv.CSRepo }}:{{`{{ .Tag }}`}}{{ if ne $b "std" }}-{{ $b }}{{ end }}
+    image_templates:
+      - {{ $bv.CSRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}amd64
+      - {{ $bv.CSRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}arm64
+  {{- end}}
+  {{- else if $amd64_exists }}
+  - name_template: {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}{{ if ne $b "std" }}-{{ $b }}{{ end }}
+    image_templates:
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}amd64
+  - name_template: {{ $bv.DHRepo }}:v{{`{{ .Major }}.{{ .Minor }}{{.Prerelease}}`}}{{ if ne $b "std" }}-{{ $b }}{{ end }}
+    image_templates:
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}amd64
+  - name_template: {{ $bv.DHRepo }}:v{{`{{ .Major }}{{.Prerelease}}`}}{{ if ne $b "std" }}-{{ $b }}{{ end }}
+    image_templates:
+      - {{ $bv.DHRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}amd64
+  {{- if $bv.CSRepo }}
+  - name_template: {{ $bv.CSRepo }}:{{`{{ .Tag }}`}}{{ if ne $b "std" }}-{{ $b }}{{ end }}
+    image_templates:
+      - {{ $bv.CSRepo }}:{{`{{ .Tag }}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}amd64
+  {{- end}}
+  {{- end }}
+  {{- end }}
+  {{- if eq $r.Name "tyk" }}
+  {{- $std_build := index .Branchvals.Builds "std" }}
+  {{- $amd64_exists := false }}
+  {{- $arm64_exists := false }}
+  {{- range $a := $std_build.Archs }}
+    {{- if eq $a.Go "amd64" }}{{ $amd64_exists = true }}{{ end }}
+    {{- if eq $a.Go "arm64" }}{{ $arm64_exists = true }}{{ end }}
+  {{- end }}
+  {{- if and $amd64_exists $arm64_exists }}
   - name_template: tykio/tyk-hybrid-docker:{{`{{ .Tag }}`}}
     image_templates:
       - tykio/tyk-hybrid-docker:{{`{{ .Tag }}`}}-amd64
       - tykio/tyk-hybrid-docker:{{`{{ .Tag }}`}}-arm64
-  {{- end }}
-  {{- if .CSRepo }}
-  - name_template: {{ .CSRepo }}:{{`{{ .Tag }}`}}
+  {{- else if $amd64_exists }}
+  - name_template: tykio/tyk-hybrid-docker:{{`{{ .Tag }}`}}
     image_templates:
-      - {{ .CSRepo }}:{{`{{ .Tag }}`}}-amd64
-      - {{ .CSRepo }}:{{`{{ .Tag }}`}}-arm64
-  {{- end}}
+      - tykio/tyk-hybrid-docker:{{`{{ .Tag }}`}}-amd64
+  {{- end }}
+  {{- end }}
 {{ end }}

--- a/policy/templates/subtemplates/goreleaser.yml.d/dockers.gotmpl
+++ b/policy/templates/subtemplates/goreleaser.yml.d/dockers.gotmpl
@@ -1,26 +1,26 @@
 {{define "dockers"}}
 dockers:
   {{- $r := . }}
-  {{- range $arch := list "amd64" "arm64" }}
-  {{- /* range over all the supported archs.
-    Except for the archs, everything else stays the same for docker templates */}}
-  # Build {{$r.DHRepo}}{{ if $r.CSRepo }}, {{ $r.CSRepo }}{{ end }} ({{ $arch }})
+  {{- range $b, $bv := .Branchvals.Builds }}
+  {{- range $a := $bv.Archs }}
+  {{- if or (eq $a.Docker "linux/amd64") (eq $a.Docker "linux/arm64") }}
+  # Build {{$bv.DHRepo}}{{ if $bv.CSRepo }}, {{ $bv.CSRepo }}{{ end }} {{ $b }} ({{ $a.Go }})
   - ids:
-      - std
+      - {{ printf "%s-%s" $b $a.Go }}
     image_templates:
-      - "{{$r.DHRepo}}:{{`{{.Tag}}`}}-{{ $arch }}"
-    {{- if $r.CSRepo }}
-      - "{{$r.CSRepo}}:{{`{{.Tag}}`}}-{{ $arch }}"
+      - "{{$bv.DHRepo}}:{{`{{.Tag}}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}{{ $a.Go }}"
+    {{- if $bv.CSRepo }}
+      - "{{$bv.CSRepo}}:{{`{{.Tag}}`}}-{{ if ne $b "std" }}{{ $b }}-{{ end }}{{ $a.Go }}"
     {{- end}}
     build_flag_templates:
       - "--build-arg=PORTS={{ $r.ExposePorts }}"
-      - "--platform=linux/{{ $arch }}"
+      - "--platform={{ $a.Docker }}"
       - "--label=org.opencontainers.image.created={{`{{.Date}}`}}"
-      - "--label=org.opencontainers.image.title={{`{{.ProjectName}}`}}"
+      - "--label=org.opencontainers.image.title={{`{{.ProjectName}}`}}{{ if ne $b "std" }} {{ upper $b }}{{ end }}"
       - "--label=org.opencontainers.image.revision={{`{{.FullCommit}}`}}"
       - "--label=org.opencontainers.image.version={{`{{.Version}}`}}"
     use: buildx
-    goarch: {{ $arch }}
+    goarch: {{ $a.Go }}
     goos: linux
     dockerfile: ci/Dockerfile.std
     extra_files:
@@ -50,29 +50,33 @@ dockers:
       - "LICENSE.md"
       - "pump.example.conf"
       {{- end}}
+  {{- end}}
+  {{- end}}
+  {{- end}}
 
-      {{- if (eq $r.Name "tyk") }}
-
-  # Build gateway hybrid container {{ $arch }}
+  {{- if (eq $r.Name "tyk") }}
+  {{- range $a := .Branchvals.Builds.std.Archs }}
+  {{- if or (eq $a.Docker "linux/amd64") (eq $a.Docker "linux/arm64") }}
+  # Build gateway hybrid container ({{ $a.Go }})
   - ids:
-      - std
+      - std-{{ $a.Go }}
     image_templates:
-      - "tykio/tyk-hybrid-docker:{{`{{.Tag}}`}}-{{ $arch }}"
+      - "tykio/tyk-hybrid-docker:{{`{{.Tag}}`}}-{{ $a.Go }}"
     build_flag_templates:
-      - "--platform=linux/{{ $arch }}"
+      - "--platform={{ $a.Docker }}"
       - "--label=org.opencontainers.image.created={{`{{.Date}}`}}"
       - "--label=org.opencontainers.image.title={{`{{.ProjectName}}`}}-hybrid"
       - "--label=org.opencontainers.image.revision={{`{{.FullCommit}}`}}"
       - "--label=org.opencontainers.image.version={{`{{.Version}}`}}"
     use: buildx
-    goarch: {{ $arch }}
+    goarch: {{ $a.Go }}
     goos: linux
     dockerfile: ci/images/hybrid/Dockerfile
     extra_files:
       - "ci/images/hybrid/"
-
+  {{- end}}
+  {{- end}}
   # The plugin compiler image is built outside of goreleaser in a
   # plugin-compiler-build workflow.
-      {{- end}}{{/* hybrid definition end */}}
-    {{- end}}{{/* range end */}}
-  {{end}}{{/* end of definition */}}
+  {{- end}}{{/* hybrid definition end */}}
+{{end}}{{/* end of definition */}}


### PR DESCRIPTION
## Motivation and Context

These changes are in response to a customer request for fips compliant docker images. These are provided by using our existing fips binaries in a distroless image. THESE ARE NOT FIPS VALIDATED IMAGES. [see this ticket](https://tyktech.atlassian.net/browse/TT-15334)

## Types of changes

changes to config.yaml -> adding dockerhub repo for fips images for tyk, tyk-analytics, tyk-pump and tyk-sink
changes to dockers.gotmpl -> this template should now be able to identify the type of binary used for the docker image (eg std or fips)
changes to docker_manifests.gotmpl -> this template should now be able to identify the type of binary used for the docker image (eg std or fips)
changes to goreleaser.yaml -> this now includes the dockers and docker manifests templates

