### PR TITLE
[TT-17002] fix: add missing push triggers to TUI prod-variations config

### DIFF
--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -152,9 +152,13 @@ level: # testsuites
             level: # testsuite
               tyk:
               tyk-analytics:
-      release-5.6:   
+      release-5.6:
         level: # trigger
           pull_request:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
+          push:
             level: # testsuite
               tyk:
               tyk-analytics:
@@ -190,7 +194,7 @@ level: # testsuites
             level: # testsuite
               tyk:
               tyk-analytics:
-      release-5.12:   
+      release-5.12:
         level: # trigger
           pull_request:
             level: # testsuite
@@ -202,7 +206,11 @@ level: # testsuites
                     db: "mongo8"
                     apimarkers: "not local and not dind"
                     sink: "$ECR/tyk-sink:master"
-      release-5.12.1:   
+          push:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
+      release-5.12.1:
         level: # trigger
           pull_request:
             level: # testsuite
@@ -214,7 +222,11 @@ level: # testsuites
                     db: "mongo8"
                     apimarkers: "not local and not dind"
                     sink: "$ECR/tyk-sink:master"
-      release-5.13:   
+          push:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
+      release-5.13:
         level: # trigger
           pull_request:
             level: # testsuite
@@ -226,6 +238,10 @@ level: # testsuites
                     db: "mongo8"
                     apimarkers: "not local and not dind"
                     sink: "$ECR/tyk-sink:master"
+          push:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
       release-6.0:   
         level: # trigger
           pull_request:
@@ -338,7 +354,23 @@ level: # testsuites
           push:
             level: # testsuite
               tyk-analytics:
-      release-5.12.1:    
+      release-5.12:
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk-analytics:
+          push:
+            level: # testsuite
+              tyk-analytics:
+      release-5.12.1:
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk-analytics:
+          push:
+            level: # testsuite
+              tyk-analytics:
+      release-5.13:
         level: # trigger
           pull_request:
             level: # testsuite


### PR DESCRIPTION
## Summary
Several release branches were missing `push` trigger configuration in `prod-variations.yml`, causing test-controller jobs to return 404 on push events (merges, cherry-picks to release branches).

### API section — added `push` triggers:
- `release-5.6`
- `release-5.12`
- `release-5.12.1`
- `release-5.13`

### UI section — added missing branch entries:
- `release-5.12` (completely absent)
- `release-5.13` (completely absent)

## Impact
Without push triggers, any merge/cherry-pick to these branches causes the test-controller jobs to fail (TUI returns HTML 404), which cascades to skip all api-tests, upgrade-deb, upgrade-rpm jobs.

## Test plan
- [ ] Push to release-5.12.1 triggers test-controller-api successfully
- [ ] Push to release-5.12 triggers test-controller-api successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)