### PR TITLE
[TT-17030] Migrate release workflow from PAT to GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,13 @@ jobs:
       id-token: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -46,7 +53,7 @@ jobs:
           version: "~> v2"
           args: release --clean ${{ !startsWith(github.ref, 'refs/tags/') && '--snapshot' || '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: find amd64 linux binary
         id: binary
@@ -80,12 +87,19 @@ jobs:
           - owner: TykTechnologies
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
       - name: checkout ${{matrix.repo}}/${{matrix.branch}}
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           repository: ${{ matrix.owner }}/${{ matrix.repo }}
           ref: ${{ matrix.branch }}
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: ${{ matrix.repo }}
           fetch-depth: 1
 
@@ -104,7 +118,7 @@ jobs:
       - name: update ${{ matrix.repo }}
         if: ${{ (github.event_name == 'push' && github.ref_name == 'master') || endsWith(github.head_ref, 'releng') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -eo pipefail
           ${{ steps.gromit.outputs.bin }} policy sync ${{ matrix.repo }}


### PR DESCRIPTION
## Summary

- Replace `secrets.ORG_GH_TOKEN` (PAT) with GitHub App token (`actions/create-github-app-token`) in the release workflow
- Add `app-token` step to 2 jobs: `goreleaser`, `doctor`
- Goreleaser job: token used as `GITHUB_TOKEN` env var for goreleaser publish
- Doctor job: token used for cross-repo checkout and `GITHUB_TOKEN` for gromit policy sync

## Test plan

- [ ] Verify the release workflow runs successfully on a PR
- [ ] Confirm goreleaser build and publish works with app token
- [ ] Confirm doctor job can checkout and sync policies across repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)