### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -210,7 +210,7 @@
           find /go/src -name vendor | xargs --no-run-if-empty -d'\n' rm -rf
           rm -rf vendor
           {{ end -}}
-          git config --global url."https://{{`${{ steps.app-token.outputs.token }}`}}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:{{`${{ steps.app-token.outputs.token }}`}}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/{{ .Name }}
           goreleaser release --clean -f {{`${{ matrix.goreleaser }}`}} {{`${{ !startsWith(github.ref, 'refs/tags/') && ' --snapshot --skip=sign,docker' || '--skip=docker' }}`}}' | tee /tmp/build.sh
           chmod +x /tmp/build.sh

--- a/policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl
@@ -255,7 +255,7 @@
           echo "📦 Updating tyk-gateway dependency to branch: $GATEWAY_BRANCH"
 
           # Configure git for go get
-          git config --global url."https://${ORG_GH_TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${ORG_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
           # Update dependency using branch name
           go get github.com/TykTechnologies/tyk@$GATEWAY_BRANCH
@@ -342,7 +342,7 @@
           cat > /tmp/build-dashboard.sh <<'EOF'
           #!/bin/sh
           set -eax
-          git config --global url."https://${ORG_GH_TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${ORG_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
           git config --global --add safe.directory /go/src/github.com/TykTechnologies/tyk-analytics
 
           # Build packages for current platform (GOOS and GOARCH are set via docker -e)

--- a/policy/templates/subtemplates/auto/auto-test.gotmpl
+++ b/policy/templates/subtemplates/auto/auto-test.gotmpl
@@ -145,7 +145,7 @@
         env:
           TOKEN: '{{`${{ steps.app-token.outputs.token }}`}}'
         run: >
-          git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Execute UI tests
         timeout-minutes: 30
         uses: TykTechnologies/github-actions/.github/actions/tests/ui-tests@42304edda365365e0a887cf018d8edc34b960b82  # main


### PR DESCRIPTION
## Summary
- Fix `git config insteadOf` pattern in gromit policy templates to use `x-access-token:` prefix and trailing slashes
- Affects release workflow templates and auto-test sub-template
- The bare token pattern fails when `actions/checkout` has set up a credential helper; the `x-access-token:` prefix ensures the URL rewrite takes precedence

## Files changed
- `policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl` — 2 replacements (uses `${ORG_GH_TOKEN}`)
- `policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl` — 1 replacement (uses Go template wrapped token)
- `policy/templates/subtemplates/auto/auto-test.gotmpl` — 1 replacement (uses `${TOKEN}`)

## Test plan
- [ ] Verify rendered templates produce correct `git config` commands
- [ ] Verify downstream repos that consume these templates work with the new pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)