### PR TITLE
[TT-16815] feat: add release-5.3 config and fix build template gating

### DIFF
--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -174,12 +174,19 @@ If --pr is supplied, a PR will be created with the changes and @devops will be a
 				break
 			}
 			if pr {
+				prTitle, _ := cmd.Flags().GetString("title")
+				jiraID, _ := cmd.Flags().GetString("jira")
 				prOpts := &policy.PullRequest{
 					BaseBranch: repo.Branch(),
 					PrBranch:   pushOpts.RemoteBranch,
 					Owner:      owner,
 					Repo:       repoName,
 					AutoMerge:  autoMerge,
+					Jira: &policy.JiraIssue{
+						Id:    jiraID,
+						Title: prTitle,
+						Body:  "Auto-generated from gromit templates by policy sync.",
+					},
 				}
 				pr, err := gh.CreatePR(rp, prOpts)
 				if err != nil {
@@ -259,6 +266,7 @@ var generateTuiCmd = &cobra.Command{
 func init() {
 	syncSubCmd.Flags().Bool("pr", false, "Create PR")
 	syncSubCmd.Flags().String("title", "", "Title of PR, required if --pr is present")
+	syncSubCmd.Flags().String("jira", "releng", "Jira ticket ID to use in the PR title, e.g. TT-12345")
 	syncSubCmd.Flags().String("msg", "Auto generated from templates by gromit", "Commit message for the automated commit by gromit.")
 	syncSubCmd.MarkFlagsRequiredTogether("pr", "title")
 	syncSubCmd.Flags().StringVar(&owner, "owner", "TykTechnologies", "Github org")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -99,6 +99,7 @@ policy:
                   docker: linux/s390x
             # ee builds are enterprise
             ee:
+              feature: ee
               flags:
                 - -tags=goplugin,ee
                 - -trimpath
@@ -183,24 +184,43 @@ policy:
                 - release-test
                 - distroless
                 - fips
+                - ee
+                - resolve-dashboard
+            release-5.3:
+              buildenv: 1.24-bullseye
+              features:
+                - release-test
+                - distroless
+                - fips
+              builds:
+                fips:
+                  flags:
+                    - -tags=goplugin,fips
+                    - -trimpath
             release-5.8:
               buildenv: 1.25-bullseye
               features:
                 - release-test
                 - distroless
                 - fips
+                - ee
+                - resolve-dashboard
             release-5.10:
               buildenv: 1.25-bullseye
               features:
                 - release-test
                 - distroless
                 - fips
+                - ee
+                - resolve-dashboard
             release-5.11:
               buildenv: 1.25-bullseye
               features:
                 - release-test
                 - distroless
                 - fips
+                - ee
+                - resolve-dashboard
             release-5.12:
               buildenv: 1.25-bullseye
               builds:
@@ -220,6 +240,8 @@ policy:
               features:
                 - release-test
                 - distroless
+                - ee
+                - resolve-dashboard
 
         tyk-analytics:
           pcrepo: tyk-dashboard-unstable
@@ -292,6 +314,13 @@ policy:
               cgo: false
               features:
                 - nightly-e2e
+                - distroless
+                - release-test
+                - fips
+            release-5.3:
+              buildenv: 1.24-bullseye
+              cgo: false
+              features:
                 - distroless
                 - release-test
                 - fips

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -191,12 +191,6 @@ policy:
               features:
                 - release-test
                 - distroless
-                - fips
-              builds:
-                fips:
-                  flags:
-                    - -tags=goplugin,fips
-                    - -trimpath
             release-5.8:
               buildenv: 1.25-bullseye
               features:
@@ -323,7 +317,6 @@ policy:
               features:
                 - distroless
                 - release-test
-                - fips
             release-5.8:
               buildenv: 1.25-bullseye
               cgo: false

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -271,12 +271,17 @@ func mergeBuilds(r, b buildMap) buildMap {
 		cp := *v
 		merged[k] = &cp
 	}
-	// Clear Archs in merged builds when branch provides its own,
+	// Clear Archs and Flags in merged builds when branch provides its own,
 	// so mergo doesn't append to the existing list.
 	for k, bv := range b {
-		if bv != nil && len(bv.Archs) > 0 {
+		if bv != nil {
 			if m, ok := merged[k]; ok {
-				m.Archs = nil
+				if len(bv.Archs) > 0 {
+					m.Archs = nil
+				}
+				if len(bv.Flags) > 0 {
+					m.Flags = nil
+				}
 			}
 		}
 	}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -47,12 +47,14 @@ func TestPolicyConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not set main branch: %v", err)
 	}
-	assert.EqualValues(t, []string{"flagstd1", "flagstd2"}, repo1.Branchvals.Builds["std"].Flags, "testing explicit merge")
+	// When branch defines Flags, they replace repo-level Flags (not append)
+	// to allow branch overrides to remove unwanted build tags (e.g. stripping ee from fips builds)
+	assert.EqualValues(t, []string{"flagstd2"}, repo1.Branchvals.Builds["std"].Flags, "testing branch flags replace repo flags")
 	assert.EqualValues(t, "repo1-std2", repo1.Branchvals.Builds["std2"].BuildPackageName, "testing implicit merges at branch")
 	assert.EqualValues(t, []string{"flag2"}, repo1.Branchvals.Builds["std2"].Flags, "testing implicit merge from repo")
 	// When branch defines Archs, they replace repo-level Archs (not append)
 	// to prevent duplicate goreleaser build IDs
-	assert.EqualValues(t, build{Flags: []string{"flagstd1", "flagstd2"},
+	assert.EqualValues(t, build{Flags: []string{"flagstd2"},
 		BuildPackageName: "repo1-pkg",
 		DHRepo:           "repo1-doc-right",
 		Archs: []struct {

--- a/policy/templates/releng/.github/workflows/release.yml
+++ b/policy/templates/releng/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
 {{- template "goreleaser" . }}
 
-{{- if eq .Name "tyk" }}
+{{- if and (eq .Name "tyk") (has "resolve-dashboard" .Branchvals.Features) }}
 {{- template "tyk-dashboard-resolver" . }}
 {{- end }}
 

--- a/policy/templates/subtemplates/auto/auto-test.gotmpl
+++ b/policy/templates/subtemplates/auto/auto-test.gotmpl
@@ -30,11 +30,11 @@
     {{- if and (has "releng" .dot.Branchvals.Features) (ne .flow "nightly") }}
       - goreleaser
     {{- end }}
-    {{- if and (eq .dot.Name "tyk") (eq .test "api") }}
+    {{- if and (eq .dot.Name "tyk") (eq .test "api") (has "resolve-dashboard" .dot.Branchvals.Features) }}
       - resolve-dashboard-image
       - build-dashboard-image
     {{- end }}
-    {{- if and (eq .dot.Name "tyk") (eq .test "api") }}
+    {{- if and (eq .dot.Name "tyk") (eq .test "api") (has "resolve-dashboard" .dot.Branchvals.Features) }}
     # build-dashboard-image may be skipped, so use !cancelled() to run regardless
     if: |
       !cancelled() &&
@@ -117,7 +117,7 @@
         with:
           base_ref: {{`${{ env.BASE_REF }}`}}
           tags: {{`${{ needs.goreleaser.outputs.ee_tags || needs.goreleaser.outputs.std_tags || format('{0}/tyk-ee:master', steps.ecr.outputs.registry) }}`}}
-          {{- if and (eq .dot.Name "tyk") (eq .test "api") }}
+          {{- if and (eq .dot.Name "tyk") (eq .test "api") (has "resolve-dashboard" .dot.Branchvals.Features) }}
           dashboard_image: {{`${{ needs.resolve-dashboard-image.outputs.dashboard_image }}`}}
           {{- end }}
           github_token: {{`${{ steps.app-token.outputs.token }}`}}


### PR DESCRIPTION
## Summary

- Add `release-5.3` branch config for `tyk` (Go 1.24, fips without `ee` tag) and `tyk-analytics` (Go 1.24, fips)
- Gate `ee` build behind `feature: ee` flag so it doesn't appear on branches that don't have the `ee` feature (e.g. release-5.3)
- Fix `mergeBuilds` to clear `Flags` before merge — same logic already existed for `Archs` — so branch-level flag overrides replace rather than append to repo-level flags
- Add `--jira` flag to `policy sync` for structured PR title generation
- Introduce `resolve-dashboard` feature flag to gate the `tyk-dashboard-resolver` job and related `auto-test` dependencies, so older branches like release-5.3 that never had that job are unaffected

## Test plan

- [ ] `go run . policy gen /tmp/out --repo tyk --branch release-5.3` — verify fips build present with `-tags=goplugin,fips` (no `ee`, no `boringcrypto`), no `resolve-dashboard-image` job, no `ee` build
- [ ] `go run . policy gen /tmp/out --repo tyk --branch master` — verify `ee` build, fips, and `resolve-dashboard-image` job all still present
- [ ] `go run . policy gen /tmp/out --repo tyk-analytics --branch release-5.3` — verify fips build present, no `ee`
- [ ] `go run . policy sync tyk --branch release-5.3 --pr --jira TT-16815 --title "..."` — verify PR created without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)