### PR TITLE
Update TUI configuration for 5.8.14 and 5.13.0 branches

### DIFF
--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -195,6 +195,22 @@ level: # testsuites
             level: # testsuite
               tyk:
               tyk-analytics:
+      release-5.8.14:
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
+                envfiles:
+                  - cache: "valkey8"
+                    config: "murmur128"
+                    db: "mongo8"
+                    apimarkers: "not local and not dind"
+                    sink: "$ECR/tyk-sink:master"
+          push:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
       release-5.12:
         level: # trigger
           pull_request:
@@ -228,6 +244,22 @@ level: # testsuites
               tyk:
               tyk-analytics:
       release-5.13:
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
+                envfiles:
+                  - cache: "valkey8"
+                    config: "murmur128"
+                    db: "mongo8"
+                    apimarkers: "not local and not dind"
+                    sink: "$ECR/tyk-sink:master"
+          push:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
+      release-5.13.0:
         level: # trigger
           pull_request:
             level: # testsuite
@@ -353,6 +385,14 @@ level: # testsuites
           push:
             level: # testsuite
               tyk-analytics:
+      release-5.8.14:
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk-analytics:
+          push:
+            level: # testsuite
+              tyk-analytics:
       release-5.12:
         level: # trigger
           pull_request:
@@ -370,6 +410,14 @@ level: # testsuites
             level: # testsuite
               tyk-analytics:
       release-5.13:
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk-analytics:
+          push:
+            level: # testsuite
+              tyk-analytics:
+      release-5.13.0:
         level: # trigger
           pull_request:
             level: # testsuite


### PR DESCRIPTION
## Problem

`test-controller-*` jobs fail on PRs targeting `release-5.13.0` and `release-5.8.14` because TUI returns 404 for those unregistered branches. The `test-controller` action pipes the response straight into `$GITHUB_OUTPUT`, so the GitHub Pages 404 HTML lands there and crashes the runner with `Invalid format '<!DOCTYPE html>'`.

Affected PRs (all auto-generated swagger updates by the probelabs bot, blocked):
- TykTechnologies/tyk#8170 (release-5.13.0)
- TykTechnologies/tyk#8171 (release-5.8.14)
- TykTechnologies/tyk-analytics#5577 (release-5.13.0)
- TykTechnologies/tyk-analytics#5578 (release-5.8.14)

## Changes

In `config/tui/prod-variations.yml`:
- Added `release-5.8.14` under `api` and `ui` by duplicating the existing `release-5.8.13` blocks.
- Added `release-5.13.0` under `api` and `ui` by duplicating the existing `release-5.13` blocks.

Same pattern as #446 (5.8.13 / 5.12.1 branches).

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` — parses cleanly
- `go test ./policy/...` — PASS
- `gromit policy generate-tui --config-dir config/tui --out-dir /tmp/out` — produces the expected `.gho` files at:
  - `v2/prod-variation/{tyk,tyk-analytics}/release-5.13.0/{pull_request,push}/{api,ui}.gho`
  - `v2/prod-variation/{tyk,tyk-analytics}/release-5.8.14/{pull_request,push}/{api,ui}.gho`