### PR TITLE
[TT-16951] feat: disable FIPS for release-5.13.0

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -220,6 +220,12 @@ policy:
               features:
                 - release-test
                 - distroless
+            release-5.13.0:
+              buildenv: 1.25-bullseye
+              # FIPS disabled for 5.13.0 release
+              features:
+                - release-test
+                - distroless
 
         tyk-analytics:
           pcrepo: tyk-dashboard-unstable
@@ -322,6 +328,14 @@ policy:
             release-5.12:
               buildenv: 1.25-bullseye
               cgo: false
+              features:
+                - nightly-e2e
+                - distroless
+                - release-test
+            release-5.13.0:
+              buildenv: 1.25-bullseye
+              cgo: false
+              # FIPS disabled for 5.13.0 release
               features:
                 - nightly-e2e
                 - distroless


### PR DESCRIPTION
## Summary
Add explicit branch entries for `release-5.13.0` in both tyk and
tyk-analytics with the `fips` feature flag removed. FIPS Docker
images are not being released for 5.13.0.

## Test plan
- [ ] Generated workflows for release-5.13.0 contain no FIPS Docker steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)