### PR TITLE
fix: add condition to recover building std images for repos where ee not exists

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -287,8 +287,10 @@
         id: ci_metadata_{{ $b }}
 {{- if eq $b "ee" }}
         if: {{`${{ matrix.golang_cross == '` }}{{$r.Branchvals.Buildenv}}{{`' }}`}}
-{{- else }}
+{{- else if $r.HasBuild "ee" }}
         if: {{`${{ matrix.golang_cross == '` }}{{$r.Branchvals.Buildenv}}{{`' && github.event_name != 'pull_request' }}`}}
+{{- else }}
+        if: {{`${{ matrix.golang_cross == '` }}{{$r.Branchvals.Buildenv}}{{`' }}`}}
 {{- end }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
@@ -307,8 +309,10 @@
       - name: push {{ $b }} image to CI
 {{- if eq $b "ee" }}
         if: {{`${{ matrix.golang_cross == '` }}{{$r.Branchvals.Buildenv}}{{`' }}`}}
-{{- else }}
+{{- else if $r.HasBuild "ee" }}
         if: {{`${{ matrix.golang_cross == '` }}{{$r.Branchvals.Buildenv}}{{`' && github.event_name != 'pull_request' }}`}}
+{{- else }}
+        if: {{`${{ matrix.golang_cross == '` }}{{$r.Branchvals.Buildenv}}{{`' }}`}}
 {{- end }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:


### PR DESCRIPTION
### Description
We have steps on repos(e.g tyk-analytics) that are fetching PR based change to run the tests/actions against it. The current condition prevent building such images which result in failing workflows.

[Example-1](https://github.com/TykTechnologies/tyk-analytics/actions/runs/25668240859/job/75364434578?pr=5618)