### PR TITLE
add release-5.3.13 to tui prod-variations config

### DIFF
--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -141,7 +141,19 @@ level: # testsuites
           push:
             level: # testsuite
               tyk-identity-broker:
-      release-5.3:   
+      release-5.3:
+        pump:
+          - "tykio/tyk-pump-docker-pub:v1.14"
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
+          push:
+            level: # testsuite
+              tyk:
+              tyk-analytics:
+      release-5.3.13:
         pump:
           - "tykio/tyk-pump-docker-pub:v1.14"
         level: # trigger
@@ -351,7 +363,17 @@ level: # testsuites
             level: # repos
               tyk-analytics:
               tyk-pro:
-      release-5.3:  
+      release-5.3:
+        pump:
+          - "tykio/tyk-pump-docker-pub:v1.14"
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk-analytics:
+          push:
+            level: # testsuite
+              tyk-analytics:
+      release-5.3.13:
         pump:
           - "tykio/tyk-pump-docker-pub:v1.14"
         level: # trigger


### PR DESCRIPTION
## Summary

The `tui.internal.dev.tyk.technology` config service has no entry for `release-5.3.13`, so requests like

```
GET http://tui.internal.dev.tyk.technology/v2/prod-variation/tyk-analytics/release-5.3.13/push/ui.gho
```

return HTTP 404 with GitHub Pages' "Page not found" HTML. The `test-controller` action in [TykTechnologies/github-actions](https://github.com/TykTechnologies/github-actions/blob/main/.github/actions/tests/test-controller/action.yaml) pipes that response into `$GITHUB_OUTPUT`, and the runner rejects it:

```
Invalid format '<!DOCTYPE html>'
Unable to process file command 'output' successfully.
Process completed with exit code 22.
```

Failing job: https://github.com/TykTechnologies/tyk-analytics/actions/runs/25858991099/job/75984784954

I verified the endpoint by branch:

| Branch | HTTP | Body |
|---|---|---|
| `release-5.3` | 200 | valid `envfiles=…` |
| `release-5.13` | 200 | valid `envfiles=…` |
| `release-5.8` | 200 | valid `envfiles=…` |
| `master` | 200 | valid `envfiles=…` |
| **`release-5.3.13`** | **404** | GitHub Pages 404 HTML |

## Changes

Adds `release-5.3.13` entries under both `api` and `ui` levels, mirroring the existing `release-5.3` configuration (including the pinned `tykio/tyk-pump-docker-pub:v1.14` pump). Also dropped trailing whitespace on the two adjacent `release-5.3:` lines I was editing next to — minor and incidental.

## Test plan

- [ ] After merge and config publish, `curl http://tui.internal.dev.tyk.technology/v2/prod-variation/tyk-analytics/release-5.3.13/push/ui.gho` returns HTTP 200 with a valid `envfiles=…` body.
- [ ] Re-run the failing tyk-analytics Release workflow on `release-5.3.13`; `test-controller-ui` should pass the "Set test parameters" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)