### PR TITLE
TT-16922: add lts-version test type for tyk-analytics resilience pipeline

### DIFF
--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -323,30 +323,14 @@ level: # testsuites
             level: # repo
               tyk-analytics:
                 envfiles:
-                  - cache: "valkey8"
-                    config: "sha256"
-                    db: "mongo8"
-                    apimarkers: "not local and not dind"
-                    gwdash: release-5.3
-                  - cache: "valkey8"
-                    config: "sha256"
-                    db: "mongo8"
-                    apimarkers: "not local and not dind"
-                    gwdash: release-5.8
+                  - gwdash: release-5.3
+                  - gwdash: release-5.8
           workflow_dispatch:
             level: # repo
               tyk-analytics:
                 envfiles:
-                  - cache: "valkey8"
-                    config: "sha256"
-                    db: "mongo8"
-                    apimarkers: "not local and not dind"
-                    gwdash: release-5.3
-                  - cache: "valkey8"
-                    config: "sha256"
-                    db: "mongo8"
-                    apimarkers: "not local and not dind"
-                    gwdash: release-5.8
+                  - gwdash: release-5.3
+                  - gwdash: release-5.8
   ui:
     level: # branches
       master:

--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -324,8 +324,8 @@ level: # testsuites
               tyk-analytics:
                 envfiles:
                   - gwdash: master
-                  - gwdash: release-5.3
                   - gwdash: release-5.8
+                  - gwdash: release-5.13
   ui:
     level: # branches
       master:

--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -323,12 +323,7 @@ level: # testsuites
             level: # repo
               tyk-analytics:
                 envfiles:
-                  - gwdash: release-5.3
-                  - gwdash: release-5.8
-          workflow_dispatch:
-            level: # repo
-              tyk-analytics:
-                envfiles:
+                  - gwdash: master
                   - gwdash: release-5.3
                   - gwdash: release-5.8
   ui:

--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -315,6 +315,38 @@ level: # testsuites
             level: # testsuite
               tyk:
               tyk-analytics:
+  lts-version:
+    level: # branches
+      master:
+        level: # trigger
+          schedule:
+            level: # repo
+              tyk-analytics:
+                envfiles:
+                  - cache: "valkey8"
+                    config: "sha256"
+                    db: "mongo8"
+                    apimarkers: "not local and not dind"
+                    gwdash: release-5.3
+                  - cache: "valkey8"
+                    config: "sha256"
+                    db: "mongo8"
+                    apimarkers: "not local and not dind"
+                    gwdash: release-5.8
+          workflow_dispatch:
+            level: # repo
+              tyk-analytics:
+                envfiles:
+                  - cache: "valkey8"
+                    config: "sha256"
+                    db: "mongo8"
+                    apimarkers: "not local and not dind"
+                    gwdash: release-5.3
+                  - cache: "valkey8"
+                    config: "sha256"
+                    db: "mongo8"
+                    apimarkers: "not local and not dind"
+                    gwdash: release-5.8
   ui:
     level: # branches
       master:


### PR DESCRIPTION
## Summary

Jira: [TT-16922](https://tyktech.atlassian.net/browse/TT-16922)

Adds a new `lts-version` test type for `tyk-analytics` to support the LTS resilience pipeline ([tyk-analytics#5681](https://github.com/TykTechnologies/tyk-analytics/pull/5681)).

The `k8s-api-tests.yaml` pipeline uses the `test-controller` action with `test_type: lts-version` to dynamically fetch the active LTS versions to test against, rather than hardcoding them.

**LTS versions added** (per [Tyk LTS timeline](https://tyk.io/docs/developer-support/release-types/long-term-support#current-lts-releases-timeline)):
- `release-5.3` — Maintenance Support (active until August 2026)
- `release-5.8` — Full Support (active until June 2026)

Both `schedule` and `workflow_dispatch` triggers are configured so the pipeline can be tested manually from the GitHub Actions UI.

[TT-16922]: https://tyktech.atlassian.net/browse/TT-16922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ