### PR TITLE
[TT-16951] fix: add ee+resolve-dashboard features to release-5.13.0

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -242,6 +242,8 @@ policy:
                 - release-test
                 - distroless
                 - fips
+                - ee
+                - resolve-dashboard
 
         tyk-analytics:
           pcrepo: tyk-dashboard-unstable


### PR DESCRIPTION
## Summary

Fix for the broken gromit-generated PRs in tyk #8237 and tyk-analytics #5705. PR #473 enabled FIPS for release-5.13.0 but in tyk's branch entry only listed `release-test, distroless, fips` — dropping `ee` and `resolve-dashboard`. The `ee` build in tyk has a `feature: ee` directive, so without that feature flag the generated release.yml has no EE Docker push step. Result: the FIPS Docker push steps replaced the EE ones instead of being added alongside (see https://github.com/TykTechnologies/tyk/commit/1d51bf98dc9862b26f5a48320bd8586ffb93d7e4 — `push fips image to CI` is present but `push ee image to CI` is gone).

This PR adds `ee` and `resolve-dashboard` to tyk's release-5.13.0 features list to match release-5.12 plus the new `fips` feature.

tyk-analytics has no `ee` build, so its features list (already `nightly-e2e, distroless, release-test, fips`) was correct and is not changed.

## Test plan

- [x] Regenerated release.yml locally with patched config — contains both `push ee image to CI` and `push fips image to CI` (4 total ee+fips push steps)
- [ ] Downstream tyk PR #8237 updated with regenerated workflows
- [ ] Downstream tyk-analytics PR #5705 updated with regenerated workflows