### PR TITLE
TT-17341: fix TUI CI failure due to missing release branch reference

### DIFF
--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -125,6 +125,22 @@ level: # testsuites
           push:
             level: # testsuite
               tyk-pump:
+      release-1.15.0:
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk-pump:
+          push:
+            level: # testsuite
+              tyk-pump:
+      v2.11.0:
+        level: # trigger
+          pull_request:
+            level: # testsuite
+              tyk-sink:
+          push:
+            level: # testsuite
+              tyk-sink:
       release-1.7:
         level: # trigger
           pull_request:


### PR DESCRIPTION
https://tyktech.atlassian.net/browse/TT-17341

```
change fixes the 404 failures in tyk-pump and tyk-sink test-controller CI 
steps by adding the missing TUI variations for tyk-pump/release-1.15.0 and tyk-sink/v2.11.0 
in config/tui/prod-variations.yml, so the required .gho files get generated and published.
```