### PR TITLE
[TT-17218] Update distros

### DIFF
--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -6,16 +6,13 @@ envfiles:
     gwdash: master
 distros:
   rpm:
-    - "amazonlinux:2"
     - "registry.access.redhat.com/ubi8/ubi"
     - "amazonlinux:2023"
     - "registry.access.redhat.com/ubi9/ubi"
   deb:
-    - "ubuntu:xenial"
     - "debian:bullseye"
-    - "ubuntu:bionic"
-    - "ubuntu:focal"
     - "ubuntu:jammy"
+    - "ubuntu:noble"
     - "debian:bookworm"
     - "debian:trixie"
 pump:


### PR DESCRIPTION
Update in prod-variation file to avoid execution upgrade tests on not supported distros:
- Removes end-of-life RPM distro: amazonlinux:2 (EOL June 2025)
- Removes end-of-life DEB distros: ubuntu:xenial (EOL 2021), ubuntu:bionic (EOL 2023), ubuntu:focal (EOL 2025)
- Adds ubuntu:noble (Ubuntu 24.04 LTS, supported until 2029) to the DEB test matrix