### PR TITLE
[TT-17496] Increase timeout on nightly execution

### DIFF
--- a/policy/templates/subtemplates/auto/auto-test.gotmpl
+++ b/policy/templates/subtemplates/auto/auto-test.gotmpl
@@ -188,7 +188,7 @@
       {{ if eq .test "api" }}
       - name: Run API tests
         uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@production
-        timeout-minutes: 45
+        timeout-minutes: {{ if eq .flow "nightly" }}65{{ else }}45{{ end }}
         id: test_execution
         with:
           user_api_secret: {{`${{ steps.env_up.outputs.USER_API_SECRET }}`}}


### PR DESCRIPTION
Nightly execution of API tests now takes longer than 45 min - we need to increase timeout. This change is needed at least until we will have tests running in parallel