### PR TITLE
TT-17664: Fix Dockerfile linter warnings and syntax errors

### DIFF
--- a/policy/templates/distroless/ci/Dockerfile.distroless
+++ b/policy/templates/distroless/ci/Dockerfile.distroless
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # The _ after the pkg name is to match tyk-gateway strictly and not tyk-gateway-fips (for example)
 COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
 ARG NONROOT_CHOWN=false
-RUN dpkg -i /${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb && rm /*.deb \
+RUN dpkg -i /"${BUILD_PACKAGE_NAME}"_*"${TARGETARCH}".deb && rm /*.deb \
     && chmod -R a+rX /opt/{{ .PackageName }}/ \
     && mkdir -p /opt/{{ .PackageName }}/middleware/bundles \
     && chmod a+rwX /opt/{{ .PackageName }}/middleware /opt/{{ .PackageName }}/middleware/bundles \
@@ -31,7 +31,7 @@ ENTRYPOINT ["/opt/{{ .PackageName }}/{{ .Binary }}" ]
 ENV PROVIDER_NAME="Tyk Dashboard (Edit me)"
 ENV PROVIDER_DATA="{}"
 
-CMD [/opt/{{ .PackageName }}/{{ .Binary }}]
+CMD ["/opt/{{ .PackageName }}/{{ .Binary }}"]
 {{- else }}
 CMD [ "--conf=/opt/{{ .PackageName }}/{{ .Branchvals.ConfigFile }}" ]
 {{- end }}

--- a/policy/templates/releng/ci/Dockerfile.std
+++ b/policy/templates/releng/ci/Dockerfile.std
@@ -20,7 +20,7 @@ RUN rm -fv /usr/bin/passwd /usr/sbin/adduser || true
 
 # Comment this to test in dev
 COPY dist/${BUILD_PACKAGE_NAME}_*_${TARGETARCH}.deb /
-RUN dpkg -i /${BUILD_PACKAGE_NAME}_*_${TARGETARCH}.deb && find / -maxdepth 1 -name "*.deb" -delete
+RUN dpkg -i /"${BUILD_PACKAGE_NAME}"_*_"${TARGETARCH}".deb && find / -maxdepth 1 -name "*.deb" -delete
 
 # Clean up caches, unwanted .a and .o files
 RUN rm -rf /root/.cache \


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation/context for this pull request. -->
Fixes Dockerfile linter warnings and syntax errors in the releng and distroless templates:
- Double-quoted variables `${BUILD_PACKAGE_NAME}` and `${TARGETARCH}` in `RUN dpkg -i` commands to prevent shell word splitting.
- Added missing double quotes inside the `CMD` array brackets in `Dockerfile.distroless` to ensure valid exec form.
**Jira Ticket:** [TT-17664](https://tyktech.atlassian.net/browse/TT-17664)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / documentation / template sync

## Verification & Testing

<!-- Please describe the tests that you ran to verify your changes. -->

- [ ] I have run local unit tests (`go test ./policy/...`) and they passed.
- [ ] I have generated policy outputs locally (`go run . policy gen`) and verified the rendered files.
- [ ] I have verified the changes in target downstream repositories (e.g. `tyk`, `tyk-analytics`).

### Command(s) used for testing:

```bash
# Example: go run . policy gen /tmp/output --repo tyk --branch master
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


[TT-17664]: https://tyktech.atlassian.net/browse/TT-17664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ