### PR TITLE
TT-17664: Resolve security hotspot by restricting write permissions to owner and group 0

### DIFF
--- a/policy/templates/distroless/ci/Dockerfile.distroless
+++ b/policy/templates/distroless/ci/Dockerfile.distroless
@@ -13,9 +13,10 @@ COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
 ARG NONROOT_CHOWN=false
 RUN dpkg -i /"${BUILD_PACKAGE_NAME}"_*"${TARGETARCH}".deb && rm /*.deb \
     && chmod -R a+rX /opt/{{ .PackageName }}/ \
+    {{- if eq .Name "tyk" }}
     && mkdir -p /opt/{{ .PackageName }}/middleware/bundles \
-    && chown -R 65532:0 /opt/{{ .PackageName }}/middleware /opt/{{ .PackageName }}/middleware/bundles \
-    && chmod -R ug+rwX /opt/{{ .PackageName }}/middleware /opt/{{ .PackageName }}/middleware/bundles \
+    && chmod a+rwX /opt/{{ .PackageName }}/middleware /opt/{{ .PackageName }}/middleware/bundles \
+    {{- end }}
     && if [ "$NONROOT_CHOWN" = "true" ]; then chown -R 65532:65532 /opt/{{ .PackageName }}/; fi
 
 FROM ${BASE_IMAGE}

--- a/policy/templates/distroless/ci/Dockerfile.distroless
+++ b/policy/templates/distroless/ci/Dockerfile.distroless
@@ -14,7 +14,8 @@ ARG NONROOT_CHOWN=false
 RUN dpkg -i /"${BUILD_PACKAGE_NAME}"_*"${TARGETARCH}".deb && rm /*.deb \
     && chmod -R a+rX /opt/{{ .PackageName }}/ \
     && mkdir -p /opt/{{ .PackageName }}/middleware/bundles \
-    && chmod a+rwX /opt/{{ .PackageName }}/middleware /opt/{{ .PackageName }}/middleware/bundles \
+    && chown -R 65532:0 /opt/{{ .PackageName }}/middleware /opt/{{ .PackageName }}/middleware/bundles \
+    && chmod -R ug+rwX /opt/{{ .PackageName }}/middleware /opt/{{ .PackageName }}/middleware/bundles \
     && if [ "$NONROOT_CHOWN" = "true" ]; then chown -R 65532:65532 /opt/{{ .PackageName }}/; fi
 
 FROM ${BASE_IMAGE}


### PR DESCRIPTION
## Description
Resolves the Dockerfile security hotspot (`Make sure granting write access to others is safe here`) in the distroless template:
- Restricted write permissions for `/opt/{{ .PackageName }}/middleware` and `/opt/{{ .PackageName }}/middleware/bundles` directories from world-writable (`a+rwX`) to only the **Owner and Group** (`ug+rwX`).
- Changed directory ownership to `65532:0` (nonroot user `65532` and root group `0`). This ensures the directories remain writeable by the default container user and by containers running in OpenShift/Kubernetes (which use GID 0).

**Jira Ticket:** [TT-17664](https://tyktech.atlassian.net/browse/TT-17664)
<!-- Please include a summary of the changes and the motivation/context for this pull request. -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / documentation / template sync

## Verification & Testing

<!-- Please describe the tests that you ran to verify your changes. -->

- [ ] I have run local unit tests (`go test ./policy/...`) and they passed.
- [ ] I have generated policy outputs locally (`go run . policy gen`) and verified the rendered files.
- [ ] I have verified the changes in target downstream repositories (e.g. `tyk`, `tyk-analytics`).

### Command(s) used for testing:

```bash
# Example: go run . policy gen /tmp/output --repo tyk --branch master
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


[TT-17664]: https://tyktech.atlassian.net/browse/TT-17664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ