### PR TITLE
TT-17777: backport fallback_ref for tyk release-5.14 test-controller

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -231,6 +231,8 @@ policy:
                 - ee
                 - resolve-dashboard
                 - fips
+                # DX-2386 (tyk#8451): api tests fall back to master variations
+                - test-fallback
             release-5.14.0:
               buildenv: 1.25-bullseye
               features:
@@ -239,6 +241,8 @@ policy:
                 - ee
                 - resolve-dashboard
                 - fips
+                # DX-2386 (tyk#8451): api tests fall back to master variations
+                - test-fallback
         tyk-analytics:
           pcrepo: tyk-dashboard-unstable
           dhrepo: tykio/tyk-dashboard
@@ -599,7 +603,7 @@ policy:
           configfile: tyk_sink.conf
           versionpackage: github.com/TykTechnologies/tyk-sink/main
           tests: [api]
-          builds: 
+          builds:
             std:
               description: >-
                 Tyk RPC server backend (bridge)
@@ -659,7 +663,7 @@ policy:
           upgradefromver: 0.0.1
           configfile: midsommar.conf
           versionpackage: github.com/TykTechnologies/midsommar/main
-          builds: 
+          builds:
             std:
               buildpackagename: midsommar
               description: >-
@@ -712,7 +716,7 @@ pkgs:
     # It is inverted so that if it is omitted from some repo, it will failsafe to false
     notbackup: false
     # exceptions are those versions that should not be deleted from
-    # packagecloud. These don't have to be semver. 
+    # packagecloud. These don't have to be semver.
     exceptions:
       - v2.6.2
       - v2.9.3

--- a/policy/templates/subtemplates/auto/auto-test.gotmpl
+++ b/policy/templates/subtemplates/auto/auto-test.gotmpl
@@ -23,6 +23,9 @@
           variation: {{`${{ env.VARIATION }}`}}
           base_ref: {{`${{ env.BASE_REF }}`}}
           test_type: {{ .test }}
+  {{- if has "test-fallback" .dot.Branchvals.Features }}
+          fallback_ref: master
+  {{- end }}
 
   {{ .test }}-tests:
     needs:


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation/context for this pull request. -->
```
Adds a `test-fallback` branch feature that gates a `fallback_ref: master` line on the
test-controller step in the auto-test subtemplate, and enables it for tyk
`release-5.14` and `release-5.14.0`.
```

**Jira Ticket:** [TT-17777](https://tyktech.atlassian.net/browse/TT-17777)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / documentation / template sync

## Verification & Testing

<!-- Please describe the tests that you ran to verify your changes. -->

- [ ] I have run local unit tests (`go test ./policy/...`) and they passed.
- [ ] I have generated policy outputs locally (`go run . policy gen`) and verified the rendered files.
- [ ] I have verified the changes in target downstream repositories (e.g. `tyk`, `tyk-analytics`).

### Command(s) used for testing:

```bash
# Example: go run . policy gen /tmp/output --repo tyk --branch master
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


[TT-17777]: https://tyktech.atlassian.net/browse/TT-17777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ