### PR TITLE
TT-17778: fix bug where policy sync aborts at the first in-sync branch

### DIFF
--- a/cmd/policy.go
+++ b/cmd/policy.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -154,6 +155,7 @@ If --pr is supplied, a PR will be created with the changes and @devops will be a
 			gh = policy.NewGithubClient(ghToken)
 		}
 
+		var syncErr error
 		for _, branch := range branches {
 			repo, err := policy.InitGit(fmt.Sprintf("https://github.com/%s/%s", rp.Owner, repoName),
 				branch,
@@ -169,9 +171,14 @@ If --pr is supplied, a PR will be created with the changes and @devops will be a
 				CommitMsg:    msg,
 				Repo:         repo,
 			}
-			err = rp.ProcessBranch(pushOpts)
-			if err != nil {
-				cmd.Printf("Could not process %s/%s: %v\n", repoName, branch, err)
+			syncErr = rp.ProcessBranch(pushOpts)
+			if errors.Is(syncErr, policy.ErrNoChanges) {
+				cmd.Printf("%s/%s is already in sync, skipping\n", repoName, branch)
+				syncErr = nil
+				continue
+			}
+			if syncErr != nil {
+				cmd.Printf("Could not process %s/%s: %v\n", repoName, branch, syncErr)
 				cmd.Println("Will not process remaining branches")
 				break
 			}
@@ -193,6 +200,8 @@ If --pr is supplied, a PR will be created with the changes and @devops will be a
 				pr, err := gh.CreatePR(rp, prOpts)
 				if err != nil {
 					cmd.Printf("gh create pr --base %s --head %s: %v", repo.Branch(), pushOpts.RemoteBranch, err)
+					syncErr = err
+					continue
 				}
 				prs = append(prs, *pr.HTMLURL)
 			}
@@ -201,7 +210,7 @@ If --pr is supplied, a PR will be created with the changes and @devops will be a
 		for _, pr := range prs {
 			cmd.Printf("- %s\n", pr)
 		}
-		return err
+		return syncErr
 	},
 }
 

--- a/policy/git.go
+++ b/policy/git.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,6 +21,8 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/rs/zerolog/log"
 )
+
+var ErrNoChanges = errors.New("nothing to commit, templates produced no changes")
 
 // GitRepo models a local git worktree with the authentication and
 // enough metadata to allow it to be pushed it to github
@@ -127,6 +130,9 @@ func (r *GitRepo) Branch() string {
 // Note that this commit will be lost if it is not pushed to a remote.
 func (r *GitRepo) Commit(msg string) error {
 	newCommitHash, err := r.worktree.Commit(msg, r.commitOpts)
+	if errors.Is(err, git.ErrEmptyCommit) {
+		return ErrNoChanges
+	}
 	if err != nil {
 		return err
 	}

--- a/policy/git_test.go
+++ b/policy/git_test.go
@@ -8,12 +8,38 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/TykTechnologies/gromit/config"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCommitNoChanges(t *testing.T) {
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	require.NoError(t, err)
+	w, err := repo.Worktree()
+	require.NoError(t, err)
+
+	sig := &object.Signature{Name: "test", Email: "test@test.co", When: time.Now()}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0644))
+	_, err = w.Add("f.txt")
+	require.NoError(t, err)
+	_, err = w.Commit("init", &git.CommitOptions{Author: sig})
+	require.NoError(t, err)
+
+	r := &GitRepo{
+		repo:       repo,
+		worktree:   w,
+		commitOpts: &git.CommitOptions{All: false, Author: sig},
+	}
+	err = r.Commit("no changes here")
+	assert.ErrorIs(t, err, ErrNoChanges)
+}
 
 var testRepo = map[string]string{
 	"url":         "https://github.com/tyklabs/git-tests",

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -338,6 +339,10 @@ func (rp *RepoPolicy) ProcessBranch(pushOpts *PushOptions) error {
 		}
 	}
 	err = pushOpts.Repo.Commit(pushOpts.CommitMsg)
+	if errors.Is(err, ErrNoChanges) {
+		log.Info().Msgf("%s/%s is already in sync with the templates, nothing to push", rp.Name, pushOpts.Branch)
+		return ErrNoChanges
+	}
 	if err != nil {
 		return fmt.Errorf("git commit %s: %v", pushOpts.Repo.url, err)
 	}


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation/context for this pull request. -->
```
`policy sync` processes branches alphabetically and treats a clean worktree
("cannot create empty commit") as fatal, so once a repo's master was in sync, it
aborted before reaching any release branch. A shadowed `err` also meant sync
still exited 0, leaving the doctor job green while nothing was pushed.
```

**Jira Ticket:** [TT-17778](https://tyktech.atlassian.net/browse/TT-17778)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / documentation / template sync

## Verification & Testing

<!-- Please describe the tests that you ran to verify your changes. -->

- [ ] I have run local unit tests (`go test ./policy/...`) and they passed.
- [ ] I have generated policy outputs locally (`go run . policy gen`) and verified the rendered files.
- [ ] I have verified the changes in target downstream repositories (e.g. `tyk`, `tyk-analytics`).

### Command(s) used for testing:

```bash
# Example: go run . policy gen /tmp/output --repo tyk --branch master
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


[TT-17778]: https://tyktech.atlassian.net/browse/TT-17778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ