### PR TITLE
TT-17775: Collapse duplicated branch config and add a config redundancy lint

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -52,7 +52,6 @@ policy:
       repos:
         # Repo specific policy for `tyk` starts here->
         tyk:
-          distrolessbaseimage: base-debian13:nonroot
           # packagename is the historical name of the package. Builds
           # may produce artifacts named differently but the
           # directories and contents of the package use this name.
@@ -173,74 +172,58 @@ policy:
           # official images. These tests are usually required for PRs to
           # pass so be careful with names
           tests: [api]
+          # Features common to every tyk branch. Branch entries below only
+          # add their genuine extras (features are unioned across levels).
+          features:
+            - release-test
+            - distroless
           # Different branches could have different policy as older branches
           # could be on a different releaese workflow. To override any branch
           # policy for a specific branch, they could be specified here, under
           # the respective branches.
+          # buildenv is inherited from the cgo-services group default unless
+          # overridden here.
           # Branch specific policy for different branches starts here.->
           branches:
             master:
               features:
-                - release-test
-                - distroless
                 - fips
                 - ee
                 - resolve-dashboard
             release-5.3:
               buildenv: 1.24-bullseye
-              features:
-                - release-test
-                - distroless
             release-5.8:
-              buildenv: 1.25-bullseye
               features:
-                - release-test
-                - distroless
                 - fips
                 - ee
                 - resolve-dashboard
             release-5.8.15:
-              buildenv: 1.25-bullseye
               features:
-                - release-test
-                - distroless
                 - fips
                 - ee
                 - resolve-dashboard
             release-5.13:
-              buildenv: 1.25-bullseye
               features:
-                - release-test
-                - distroless
+                - fips
                 - ee
                 - resolve-dashboard
-                - fips
             release-5.13.1:
-              buildenv: 1.25-bullseye
               features:
-                - release-test
-                - distroless
+                - fips
                 - ee
                 - resolve-dashboard
-                - fips
             release-5.14:
-              buildenv: 1.25-bullseye
               features:
-                - release-test
-                - distroless
+                - fips
                 - ee
                 - resolve-dashboard
-                - fips
                 # DX-2386 (tyk#8451): api tests fall back to master variations
                 - test-fallback
             release-5.14.0:
-              buildenv: 1.25-bullseye
               features:
-                - release-test
-                - distroless
+                - fips
                 - ee
                 - resolve-dashboard
-                - fips
                 # DX-2386 (tyk#8451): api tests fall back to master variations
                 - test-fallback
         tyk-analytics:
@@ -308,68 +291,51 @@ policy:
                   skipdocker: true
               env:
                 - GOFIPS140=v1.0.0
+          # Features common to every tyk-analytics branch. Branch entries
+          # below only add their genuine extras (features are unioned).
+          features:
+            - distroless
+            - release-test
+          # buildenv is inherited from the cgo-services group default unless
+          # overridden here.
           branches:
             master:
-              buildenv: 1.25-bullseye
               cgo: false
               features:
                 - nightly-e2e
-                - distroless
-                - release-test
                 - fips
             release-5.3:
               buildenv: 1.24-bullseye
               cgo: false
-              features:
-                - distroless
-                - release-test
             release-5.8:
-              buildenv: 1.25-bullseye
               cgo: false
               features:
                 - nightly-e2e
-                - distroless
-                - release-test
                 - fips
             release-5.8.15:
-              buildenv: 1.25-bullseye
               cgo: false
               features:
                 - nightly-e2e
-                - distroless
-                - release-test
                 - fips
             release-5.13:
-              buildenv: 1.25-bullseye
               cgo: false
               features:
                 - nightly-e2e
-                - distroless
-                - release-test
                 - fips
             release-5.13.1:
-              buildenv: 1.25-bullseye
               cgo: false
               features:
                 - nightly-e2e
-                - distroless
-                - release-test
                 - fips
             release-5.14:
-              buildenv: 1.25-bullseye
               cgo: false
               features:
                 - nightly-e2e
-                - distroless
-                - release-test
                 - fips
             release-5.14.0:
-              buildenv: 1.25-bullseye
               cgo: false
               features:
                 - nightly-e2e
-                - distroless
-                - release-test
                 - fips
 
         portal:
@@ -443,7 +409,6 @@ policy:
           configfile: tyk-ai-studio.conf
           versionpackage: main
           features:
-            - releng
             - ai-studio-frontend-build
             - default-distros
           builds:
@@ -490,7 +455,6 @@ policy:
                   docker: linux/s390x
           branches:
             main:
-              buildenv: 1.25-bullseye
 
     pgo-services:
       features:
@@ -594,7 +558,6 @@ policy:
           branches:
             master: {}
         tyk-sink:
-          buildenv: 1.25-bookworm
           exposeports: 80
           binary: tyk-sink
           cgo: false

--- a/config/lint_test.go
+++ b/config/lint_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+var nonScalarKeys = map[string]bool{
+	"repos":        true,
+	"branches":     true,
+	"builds":       true,
+	"features":     true,
+	"deletedfiles": true,
+	"tests":        true,
+}
+
+// TestConfigRedundancy keeps config.yaml honest about its own cascade.
+//
+// Values flow group -> repo -> branch, and features are unioned across all
+// three levels. So repeating an inherited value (or feature) at a deeper
+// level does nothing - it just looks meaningful and invites drift when we
+// update one copy and miss the others. This test fails if config.yaml
+// restates anything the cascade already provides.
+func TestConfigRedundancy(t *testing.T) {
+	raw, err := os.ReadFile("config.yaml")
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	var doc struct {
+		Policy struct {
+			Groups map[string]map[string]any `yaml:"groups"`
+		} `yaml:"policy"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse config.yaml: %v", err)
+	}
+
+	var findings []string
+	var warnings []string
+
+	for gName, group := range doc.Policy.Groups {
+		groupFeatures := toStringSet(group["features"])
+
+		repos, _ := group["repos"].(map[string]any)
+		for rName, r := range repos {
+			repo, _ := r.(map[string]any)
+			if repo == nil {
+				continue
+			}
+			repoPath := fmt.Sprintf("%s.%s", gName, rName)
+
+			for k, v := range repo {
+				if nonScalarKeys[k] {
+					continue
+				}
+				if gv, ok := group[k]; ok && gv == v {
+					findings = append(findings,
+						fmt.Sprintf("%s: %q repeats the group default (%v)", repoPath, k, v))
+				}
+			}
+
+			repoFeatures := toStringSet(repo["features"])
+			for f := range repoFeatures {
+				if groupFeatures[f] {
+					findings = append(findings,
+						fmt.Sprintf("%s: feature %q is already set at group level", repoPath, f))
+				}
+			}
+
+			branches, _ := repo["branches"].(map[string]any)
+			for bName, b := range branches {
+				branch, _ := b.(map[string]any)
+				if branch == nil {
+					continue
+				}
+				branchPath := fmt.Sprintf("%s.branches.%s", repoPath, bName)
+
+				for k, v := range branch {
+					if nonScalarKeys[k] {
+						continue
+					}
+					inherited, ok := repo[k]
+					if !ok {
+						inherited, ok = group[k]
+					}
+					if ok && inherited == v {
+						findings = append(findings,
+							fmt.Sprintf("%s: %q repeats the inherited value (%v)", branchPath, k, v))
+					}
+					// Heads up: setting `<key>: false` on a branch when the repo
+					// has `<key>: true` does NOT work. Our merge (copier with
+					// IgnoreEmpty) treats false as empty and drops it, so the
+					// branch silently stays true. This is why tyk-analytics
+					// release branches say `cgo: false` but have always built
+					// with cgo on.
+					//
+					// Keeping this as a warning until we settle the
+					// tyk-analytics cgo intent; after that, we'll move it into
+					// `findings` so it fails the build.
+					if v == false && inherited == true {
+						warnings = append(warnings,
+							fmt.Sprintf("%s: %q set to false but inherits true; this override is silently ignored (the merge drops zero values), the effective value is true", branchPath, k))
+					}
+				}
+
+				for f := range toStringSet(branch["features"]) {
+					if repoFeatures[f] || groupFeatures[f] {
+						findings = append(findings,
+							fmt.Sprintf("%s: feature %q is already set at repo or group level", branchPath, f))
+					}
+				}
+			}
+		}
+	}
+
+	for _, w := range warnings {
+		t.Logf("WARNING: %s", w)
+	}
+	if len(findings) > 0 {
+		t.Errorf("config.yaml restates %d inherited value(s); remove them, the cascade already provides them:", len(findings))
+		for _, f := range findings {
+			t.Errorf("  - %s", f)
+		}
+	}
+}
+
+func toStringSet(v any) map[string]bool {
+	set := make(map[string]bool)
+	list, _ := v.([]any)
+	for _, item := range list {
+		if s, ok := item.(string); ok {
+			set[s] = true
+		}
+	}
+	return set
+}


### PR DESCRIPTION


## Description
```
Collapses duplicated branch config in config.yaml and adds a lint test that
keeps it collapsed.
- tyk, tyk-analytics, ai-studio, tyk-sink: removed branch/repo entries that
  restate values already inherited through the group -> repo -> branch cascade
  (duplicate buildenv, distrolessbaseimage, and features that are unioned in
  anyway)
- config/lint_test.go: fails CI if config.yaml restates anything the cascade
  already provides, so the duplication cannot creep back
```

<!-- Please include a summary of the changes and the motivation/context for this pull request. -->

**Jira Ticket:** [TT-17775](https://tyktech.atlassian.net/browse/TT-17775)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore / documentation / template sync

## Verification & Testing

<!-- Please describe the tests that you ran to verify your changes. -->

- [ ] I have run local unit tests (`go test ./policy/...`) and they passed.
- [ ] I have generated policy outputs locally (`go run . policy gen`) and verified the rendered files.
- [ ] I have verified the changes in target downstream repositories (e.g. `tyk`, `tyk-analytics`).

### Command(s) used for testing:

```bash
# Example: go run . policy gen /tmp/output --repo tyk --branch master
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


[TT-17775]: https://tyktech.atlassian.net/browse/TT-17775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ