### PR TITLE
TT-17525: Scope tyk-analytics release fixes in releng templates

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -11,6 +11,9 @@
       github.event.pull_request.draft == false
     name: '{{`${{ matrix.golang_cross }}`}}'
     runs-on: {{`${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}`}}
+    {{- if eq .Name "tyk-analytics" }}
+    timeout-minutes: 90
+    {{- end }}
     permissions:
       id-token: write   # AWS OIDC JWT
       contents: read    # actions/checkout

--- a/policy/templates/releng/.github/workflows/release.yml.d/smoke-tests.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/smoke-tests.gotmpl
@@ -19,6 +19,9 @@
         id: params
 
   upgrade-tests:
+    {{- if eq .Name "tyk-analytics" }}
+    if: github.event_name != 'pull_request'
+    {{- end }}
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production

--- a/policy/testdata/golden/tyk-analytics/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/master/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -844,6 +845,7 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/tests/distro-matrix@production
         id: params
   upgrade-tests:
+    if: github.event_name != 'pull_request'
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production

--- a/policy/testdata/golden/tyk-analytics/release-5.13.1/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.13.1/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -844,6 +845,7 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/tests/distro-matrix@production
         id: params
   upgrade-tests:
+    if: github.event_name != 'pull_request'
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production

--- a/policy/testdata/golden/tyk-analytics/release-5.13/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.13/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -844,6 +845,7 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/tests/distro-matrix@production
         id: params
   upgrade-tests:
+    if: github.event_name != 'pull_request'
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production

--- a/policy/testdata/golden/tyk-analytics/release-5.14.0/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.14.0/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -844,6 +845,7 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/tests/distro-matrix@production
         id: params
   upgrade-tests:
+    if: github.event_name != 'pull_request'
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production

--- a/policy/testdata/golden/tyk-analytics/release-5.14/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.14/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -844,6 +845,7 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/tests/distro-matrix@production
         id: params
   upgrade-tests:
+    if: github.event_name != 'pull_request'
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production

--- a/policy/testdata/golden/tyk-analytics/release-5.3/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.3/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -672,6 +673,7 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/tests/distro-matrix@production
         id: params
   upgrade-tests:
+    if: github.event_name != 'pull_request'
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production

--- a/policy/testdata/golden/tyk-analytics/release-5.8.15/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.8.15/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -844,6 +845,7 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/tests/distro-matrix@production
         id: params
   upgrade-tests:
+    if: github.event_name != 'pull_request'
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production

--- a/policy/testdata/golden/tyk-analytics/release-5.8/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.8/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
     runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -844,6 +845,7 @@ jobs:
         uses: TykTechnologies/github-actions/.github/actions/tests/distro-matrix@production
         id: params
   upgrade-tests:
+    if: github.event_name != 'pull_request'
     needs:
       - test-controller-distros
     uses: TykTechnologies/github-actions/.github/workflows/upgrade-tests.yml@production


### PR DESCRIPTION
Port durable fixes from [tyk-analytics#5858](https://github.com/TykTechnologies/tyk-analytics/pull/5858/) so they survive sync. Both guarded with `eq .Name "tyk-analytics"`. Ao other repositories unaffected.

- goreleaser.gotmpl: add `timeout-minutes: 90` to the goreleaser job.
- smoke-tests.gotmpl: skip upgrade-tests on PRs.

