### PR TITLE
TT-17319: Fix same-branch dashboard resolution in tyk release workflow

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl
@@ -90,10 +90,18 @@
             exit 0
           fi
 
-          BRANCH=${HEAD_REF##*/}
+          BRANCH="$HEAD_REF"
           echo "Checking for branch: $BRANCH in tyk-analytics"
 
-          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+          if ! REMOTE_REF=$(git ls-remote \
+            --heads \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" \
+            "refs/heads/$BRANCH"); then
+            echo "::error::Unable to query tyk-analytics; check GitHub App authentication and repository permissions"
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_REF" ]; then
             echo "✓ Branch '$BRANCH' exists in tyk-analytics"
             echo "branch_exists=true" >> $GITHUB_OUTPUT
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
@@ -144,6 +152,7 @@
           PR_NUMBER: {{`${{ github.event.pull_request.number }}`}}
           HAS_RELEVANT_CHANGES: {{`${{ steps.check_changes.outputs.has_relevant_changes }}`}}
           ORG_GH_TOKEN: {{`${{ secrets.ORG_GH_TOKEN }}`}}
+          GH_TOKEN: {{`${{ steps.app-token.outputs.token }}`}}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -161,12 +170,31 @@
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
             if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-              echo "    → Base branch exists in tyk-analytics, using it directly"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              if aws ecr describe-images \
+                --repository-name tyk-analytics \
+                --image-ids imageTag=${BASE_REF} \
+                --region eu-central-1 > /dev/null 2>&1; then
+                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+                echo "    → Base branch exists in tyk-analytics, using it directly"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              elif [ -n "$PR_NUMBER" ]; then
+                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
+                echo "    → Branch exists in tyk-analytics but has no ECR image"
+                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+                echo "needs_build=true" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
+              else
+                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+                echo "dashboard_image=" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=" >> $GITHUB_OUTPUT
+                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              fi
             else
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
               echo "    → Falling back to gromit default"
@@ -176,14 +204,31 @@
               echo "strategy=gromit-default" >> $GITHUB_OUTPUT
             fi
 
-          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
-            echo "    → No override needed, gromit will handle it"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
+              | jq -r '.[0].number // empty' 2>/dev/null || true)
+
+            if [ -n "$DASH_PR" ] && aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=pr-${DASH_PR} \
+              --region eu-central-1 > /dev/null 2>&1; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
+              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            else
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
+              echo "    → No open tyk-analytics PR image found for the branch"
+              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then

--- a/policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl
@@ -200,9 +200,13 @@
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
-              | jq -r '.[0].number // empty' 2>/dev/null || true)
+            # Find the tyk-analytics PR for the branch by matching its head SHA
+            # against refs/pull/*/head; needs only repository read access
+            TA_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git"
+            BRANCH_SHA=$(git ls-remote --heads "$TA_REMOTE" "refs/heads/$BRANCH" | cut -f1 || true)
+            DASH_PR=$(git ls-remote "$TA_REMOTE" 'refs/pull/*/head' 2>/dev/null \
+              | awk -v sha="$BRANCH_SHA" '$1 == sha { split($2, r, "/"); print r[3] }' \
+              | sort -n | tail -1 || true)
 
             if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
               echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"

--- a/policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/tyk-dashboard-resolver.gotmpl
@@ -167,41 +167,35 @@
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
+          # emit <strategy> <dashboard_image> <needs_build> <dashboard_branch>
+          emit() {
+            echo "strategy=$1" >> $GITHUB_OUTPUT
+            echo "dashboard_image=$2" >> $GITHUB_OUTPUT
+            echo "needs_build=$3" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$4" >> $GITHUB_OUTPUT
+          }
+
+          dash_image_exists() {
+            aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=$1 \
+              --region eu-central-1 > /dev/null 2>&1
+          }
+
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              if aws ecr describe-images \
-                --repository-name tyk-analytics \
-                --image-ids imageTag=${BASE_REF} \
-                --region eu-central-1 > /dev/null 2>&1; then
-                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-                echo "    → Base branch exists in tyk-analytics, using it directly"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
-              elif [ -n "$PR_NUMBER" ]; then
-                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
-                echo "    → Branch exists in tyk-analytics but has no ECR image"
-                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-                echo "needs_build=true" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
-              else
-                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
-                echo "dashboard_image=" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=" >> $GITHUB_OUTPUT
-                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
-              echo "    → Falling back to gromit default"
-              echo "dashboard_image=" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=" >> $GITHUB_OUTPUT
-              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              emit gromit-default "" false ""
+            elif dash_image_exists "$BASE_REF"; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              emit release-branch-match "${REGISTRY}/tyk-analytics:${BASE_REF}" false "$BASE_REF"
+            elif [ -n "$PR_NUMBER" ]; then
+              echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF' (branch exists but has no ECR image)"
+              emit build-from-base-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
+            else
+              echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+              emit gromit-default "" false ""
             fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
@@ -210,54 +204,28 @@
               "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
               | jq -r '.[0].number // empty' 2>/dev/null || true)
 
-            if [ -n "$DASH_PR" ] && aws ecr describe-images \
-              --repository-name tyk-analytics \
-              --image-ids imageTag=pr-${DASH_PR} \
-              --region eu-central-1 > /dev/null 2>&1; then
-              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
-              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"
+              emit analytics-pr-image "${REGISTRY}/tyk-analytics:pr-${DASH_PR}" false "$BRANCH"
             else
-              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
-              echo "    → No open tyk-analytics PR image found for the branch"
-              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH' (no open tyk-analytics PR image)"
+              emit build-from-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BRANCH"
             fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
-            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
-            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
-            echo "    → Will update gateway ref to $COMMIT_SHA"
-            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-            echo "strategy=build-required" >> $GITHUB_OUTPUT
+            echo "🔨 Strategy: Build dashboard from '$BASE_REF' with gateway ref $COMMIT_SHA (PR has relevant package changes)"
+            emit build-required "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
 
           # Strategy 2b: PR image exists and no relevant changes → reuse existing image
           elif [ "$IMAGE_EXISTS" = "true" ]; then
-            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
-            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+            echo "🐳 Strategy: Reuse existing PR image tyk-analytics:${IMAGE_TAG} (no relevant package changes in PR)"
+            emit reuse-pr-image "${REGISTRY}/tyk-analytics:${IMAGE_TAG}" false ""
 
           # Strategy 3: Fallback to gromit default
           else
-            echo "ℹ️ Strategy: Use gromit default"
-            echo "    → No matching branch, no existing PR image, no relevant changes"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            echo "ℹ️ Strategy: Use gromit default (no matching branch, PR image, or relevant changes)"
+            emit gromit-default "" false ""
           fi
 
           echo "=================================="

--- a/policy/testdata/golden/tyk/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/master/.github/workflows/release.yml
@@ -885,9 +885,13 @@ jobs:
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
-              | jq -r '.[0].number // empty' 2>/dev/null || true)
+            # Find the tyk-analytics PR for the branch by matching its head SHA
+            # against refs/pull/*/head; needs only repository read access
+            TA_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git"
+            BRANCH_SHA=$(git ls-remote --heads "$TA_REMOTE" "refs/heads/$BRANCH" | cut -f1 || true)
+            DASH_PR=$(git ls-remote "$TA_REMOTE" 'refs/pull/*/head' 2>/dev/null \
+              | awk -v sha="$BRANCH_SHA" '$1 == sha { split($2, r, "/"); print r[3] }' \
+              | sort -n | tail -1 || true)
 
             if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
               echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"

--- a/policy/testdata/golden/tyk/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/master/.github/workflows/release.yml
@@ -852,41 +852,35 @@ jobs:
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
+          # emit <strategy> <dashboard_image> <needs_build> <dashboard_branch>
+          emit() {
+            echo "strategy=$1" >> $GITHUB_OUTPUT
+            echo "dashboard_image=$2" >> $GITHUB_OUTPUT
+            echo "needs_build=$3" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$4" >> $GITHUB_OUTPUT
+          }
+
+          dash_image_exists() {
+            aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=$1 \
+              --region eu-central-1 > /dev/null 2>&1
+          }
+
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              if aws ecr describe-images \
-                --repository-name tyk-analytics \
-                --image-ids imageTag=${BASE_REF} \
-                --region eu-central-1 > /dev/null 2>&1; then
-                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-                echo "    → Base branch exists in tyk-analytics, using it directly"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
-              elif [ -n "$PR_NUMBER" ]; then
-                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
-                echo "    → Branch exists in tyk-analytics but has no ECR image"
-                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-                echo "needs_build=true" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
-              else
-                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
-                echo "dashboard_image=" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=" >> $GITHUB_OUTPUT
-                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
-              echo "    → Falling back to gromit default"
-              echo "dashboard_image=" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=" >> $GITHUB_OUTPUT
-              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              emit gromit-default "" false ""
+            elif dash_image_exists "$BASE_REF"; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              emit release-branch-match "${REGISTRY}/tyk-analytics:${BASE_REF}" false "$BASE_REF"
+            elif [ -n "$PR_NUMBER" ]; then
+              echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF' (branch exists but has no ECR image)"
+              emit build-from-base-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
+            else
+              echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+              emit gromit-default "" false ""
             fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
@@ -895,54 +889,28 @@ jobs:
               "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
               | jq -r '.[0].number // empty' 2>/dev/null || true)
 
-            if [ -n "$DASH_PR" ] && aws ecr describe-images \
-              --repository-name tyk-analytics \
-              --image-ids imageTag=pr-${DASH_PR} \
-              --region eu-central-1 > /dev/null 2>&1; then
-              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
-              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"
+              emit analytics-pr-image "${REGISTRY}/tyk-analytics:pr-${DASH_PR}" false "$BRANCH"
             else
-              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
-              echo "    → No open tyk-analytics PR image found for the branch"
-              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH' (no open tyk-analytics PR image)"
+              emit build-from-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BRANCH"
             fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
-            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
-            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
-            echo "    → Will update gateway ref to $COMMIT_SHA"
-            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-            echo "strategy=build-required" >> $GITHUB_OUTPUT
+            echo "🔨 Strategy: Build dashboard from '$BASE_REF' with gateway ref $COMMIT_SHA (PR has relevant package changes)"
+            emit build-required "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
 
           # Strategy 2b: PR image exists and no relevant changes → reuse existing image
           elif [ "$IMAGE_EXISTS" = "true" ]; then
-            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
-            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+            echo "🐳 Strategy: Reuse existing PR image tyk-analytics:${IMAGE_TAG} (no relevant package changes in PR)"
+            emit reuse-pr-image "${REGISTRY}/tyk-analytics:${IMAGE_TAG}" false ""
 
           # Strategy 3: Fallback to gromit default
           else
-            echo "ℹ️ Strategy: Use gromit default"
-            echo "    → No matching branch, no existing PR image, no relevant changes"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            echo "ℹ️ Strategy: Use gromit default (no matching branch, PR image, or relevant changes)"
+            emit gromit-default "" false ""
           fi
 
           echo "=================================="

--- a/policy/testdata/golden/tyk/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/master/.github/workflows/release.yml
@@ -777,10 +777,18 @@ jobs:
             exit 0
           fi
 
-          BRANCH=${HEAD_REF##*/}
+          BRANCH="$HEAD_REF"
           echo "Checking for branch: $BRANCH in tyk-analytics"
 
-          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+          if ! REMOTE_REF=$(git ls-remote \
+            --heads \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" \
+            "refs/heads/$BRANCH"); then
+            echo "::error::Unable to query tyk-analytics; check GitHub App authentication and repository permissions"
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_REF" ]; then
             echo "✓ Branch '$BRANCH' exists in tyk-analytics"
             echo "branch_exists=true" >> $GITHUB_OUTPUT
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
@@ -829,6 +837,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
           ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -846,12 +855,31 @@ jobs:
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
             if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-              echo "    → Base branch exists in tyk-analytics, using it directly"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              if aws ecr describe-images \
+                --repository-name tyk-analytics \
+                --image-ids imageTag=${BASE_REF} \
+                --region eu-central-1 > /dev/null 2>&1; then
+                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+                echo "    → Base branch exists in tyk-analytics, using it directly"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              elif [ -n "$PR_NUMBER" ]; then
+                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
+                echo "    → Branch exists in tyk-analytics but has no ECR image"
+                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+                echo "needs_build=true" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
+              else
+                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+                echo "dashboard_image=" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=" >> $GITHUB_OUTPUT
+                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              fi
             else
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
               echo "    → Falling back to gromit default"
@@ -861,14 +889,31 @@ jobs:
               echo "strategy=gromit-default" >> $GITHUB_OUTPUT
             fi
 
-          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
-            echo "    → No override needed, gromit will handle it"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
+              | jq -r '.[0].number // empty' 2>/dev/null || true)
+
+            if [ -n "$DASH_PR" ] && aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=pr-${DASH_PR} \
+              --region eu-central-1 > /dev/null 2>&1; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
+              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            else
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
+              echo "    → No open tyk-analytics PR image found for the branch"
+              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then

--- a/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
@@ -885,9 +885,13 @@ jobs:
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
-              | jq -r '.[0].number // empty' 2>/dev/null || true)
+            # Find the tyk-analytics PR for the branch by matching its head SHA
+            # against refs/pull/*/head; needs only repository read access
+            TA_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git"
+            BRANCH_SHA=$(git ls-remote --heads "$TA_REMOTE" "refs/heads/$BRANCH" | cut -f1 || true)
+            DASH_PR=$(git ls-remote "$TA_REMOTE" 'refs/pull/*/head' 2>/dev/null \
+              | awk -v sha="$BRANCH_SHA" '$1 == sha { split($2, r, "/"); print r[3] }' \
+              | sort -n | tail -1 || true)
 
             if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
               echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"

--- a/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
@@ -852,41 +852,35 @@ jobs:
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
+          # emit <strategy> <dashboard_image> <needs_build> <dashboard_branch>
+          emit() {
+            echo "strategy=$1" >> $GITHUB_OUTPUT
+            echo "dashboard_image=$2" >> $GITHUB_OUTPUT
+            echo "needs_build=$3" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$4" >> $GITHUB_OUTPUT
+          }
+
+          dash_image_exists() {
+            aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=$1 \
+              --region eu-central-1 > /dev/null 2>&1
+          }
+
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              if aws ecr describe-images \
-                --repository-name tyk-analytics \
-                --image-ids imageTag=${BASE_REF} \
-                --region eu-central-1 > /dev/null 2>&1; then
-                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-                echo "    → Base branch exists in tyk-analytics, using it directly"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
-              elif [ -n "$PR_NUMBER" ]; then
-                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
-                echo "    → Branch exists in tyk-analytics but has no ECR image"
-                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-                echo "needs_build=true" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
-              else
-                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
-                echo "dashboard_image=" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=" >> $GITHUB_OUTPUT
-                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
-              echo "    → Falling back to gromit default"
-              echo "dashboard_image=" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=" >> $GITHUB_OUTPUT
-              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              emit gromit-default "" false ""
+            elif dash_image_exists "$BASE_REF"; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              emit release-branch-match "${REGISTRY}/tyk-analytics:${BASE_REF}" false "$BASE_REF"
+            elif [ -n "$PR_NUMBER" ]; then
+              echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF' (branch exists but has no ECR image)"
+              emit build-from-base-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
+            else
+              echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+              emit gromit-default "" false ""
             fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
@@ -895,54 +889,28 @@ jobs:
               "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
               | jq -r '.[0].number // empty' 2>/dev/null || true)
 
-            if [ -n "$DASH_PR" ] && aws ecr describe-images \
-              --repository-name tyk-analytics \
-              --image-ids imageTag=pr-${DASH_PR} \
-              --region eu-central-1 > /dev/null 2>&1; then
-              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
-              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"
+              emit analytics-pr-image "${REGISTRY}/tyk-analytics:pr-${DASH_PR}" false "$BRANCH"
             else
-              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
-              echo "    → No open tyk-analytics PR image found for the branch"
-              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH' (no open tyk-analytics PR image)"
+              emit build-from-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BRANCH"
             fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
-            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
-            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
-            echo "    → Will update gateway ref to $COMMIT_SHA"
-            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-            echo "strategy=build-required" >> $GITHUB_OUTPUT
+            echo "🔨 Strategy: Build dashboard from '$BASE_REF' with gateway ref $COMMIT_SHA (PR has relevant package changes)"
+            emit build-required "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
 
           # Strategy 2b: PR image exists and no relevant changes → reuse existing image
           elif [ "$IMAGE_EXISTS" = "true" ]; then
-            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
-            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+            echo "🐳 Strategy: Reuse existing PR image tyk-analytics:${IMAGE_TAG} (no relevant package changes in PR)"
+            emit reuse-pr-image "${REGISTRY}/tyk-analytics:${IMAGE_TAG}" false ""
 
           # Strategy 3: Fallback to gromit default
           else
-            echo "ℹ️ Strategy: Use gromit default"
-            echo "    → No matching branch, no existing PR image, no relevant changes"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            echo "ℹ️ Strategy: Use gromit default (no matching branch, PR image, or relevant changes)"
+            emit gromit-default "" false ""
           fi
 
           echo "=================================="

--- a/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
@@ -777,10 +777,18 @@ jobs:
             exit 0
           fi
 
-          BRANCH=${HEAD_REF##*/}
+          BRANCH="$HEAD_REF"
           echo "Checking for branch: $BRANCH in tyk-analytics"
 
-          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+          if ! REMOTE_REF=$(git ls-remote \
+            --heads \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" \
+            "refs/heads/$BRANCH"); then
+            echo "::error::Unable to query tyk-analytics; check GitHub App authentication and repository permissions"
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_REF" ]; then
             echo "✓ Branch '$BRANCH' exists in tyk-analytics"
             echo "branch_exists=true" >> $GITHUB_OUTPUT
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
@@ -829,6 +837,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
           ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -846,12 +855,31 @@ jobs:
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
             if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-              echo "    → Base branch exists in tyk-analytics, using it directly"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              if aws ecr describe-images \
+                --repository-name tyk-analytics \
+                --image-ids imageTag=${BASE_REF} \
+                --region eu-central-1 > /dev/null 2>&1; then
+                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+                echo "    → Base branch exists in tyk-analytics, using it directly"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              elif [ -n "$PR_NUMBER" ]; then
+                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
+                echo "    → Branch exists in tyk-analytics but has no ECR image"
+                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+                echo "needs_build=true" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
+              else
+                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+                echo "dashboard_image=" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=" >> $GITHUB_OUTPUT
+                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              fi
             else
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
               echo "    → Falling back to gromit default"
@@ -861,14 +889,31 @@ jobs:
               echo "strategy=gromit-default" >> $GITHUB_OUTPUT
             fi
 
-          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
-            echo "    → No override needed, gromit will handle it"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
+              | jq -r '.[0].number // empty' 2>/dev/null || true)
+
+            if [ -n "$DASH_PR" ] && aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=pr-${DASH_PR} \
+              --region eu-central-1 > /dev/null 2>&1; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
+              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            else
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
+              echo "    → No open tyk-analytics PR image found for the branch"
+              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then

--- a/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
@@ -885,9 +885,13 @@ jobs:
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
-              | jq -r '.[0].number // empty' 2>/dev/null || true)
+            # Find the tyk-analytics PR for the branch by matching its head SHA
+            # against refs/pull/*/head; needs only repository read access
+            TA_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git"
+            BRANCH_SHA=$(git ls-remote --heads "$TA_REMOTE" "refs/heads/$BRANCH" | cut -f1 || true)
+            DASH_PR=$(git ls-remote "$TA_REMOTE" 'refs/pull/*/head' 2>/dev/null \
+              | awk -v sha="$BRANCH_SHA" '$1 == sha { split($2, r, "/"); print r[3] }' \
+              | sort -n | tail -1 || true)
 
             if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
               echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"

--- a/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
@@ -852,41 +852,35 @@ jobs:
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
+          # emit <strategy> <dashboard_image> <needs_build> <dashboard_branch>
+          emit() {
+            echo "strategy=$1" >> $GITHUB_OUTPUT
+            echo "dashboard_image=$2" >> $GITHUB_OUTPUT
+            echo "needs_build=$3" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$4" >> $GITHUB_OUTPUT
+          }
+
+          dash_image_exists() {
+            aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=$1 \
+              --region eu-central-1 > /dev/null 2>&1
+          }
+
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              if aws ecr describe-images \
-                --repository-name tyk-analytics \
-                --image-ids imageTag=${BASE_REF} \
-                --region eu-central-1 > /dev/null 2>&1; then
-                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-                echo "    → Base branch exists in tyk-analytics, using it directly"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
-              elif [ -n "$PR_NUMBER" ]; then
-                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
-                echo "    → Branch exists in tyk-analytics but has no ECR image"
-                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-                echo "needs_build=true" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
-              else
-                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
-                echo "dashboard_image=" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=" >> $GITHUB_OUTPUT
-                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
-              echo "    → Falling back to gromit default"
-              echo "dashboard_image=" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=" >> $GITHUB_OUTPUT
-              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              emit gromit-default "" false ""
+            elif dash_image_exists "$BASE_REF"; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              emit release-branch-match "${REGISTRY}/tyk-analytics:${BASE_REF}" false "$BASE_REF"
+            elif [ -n "$PR_NUMBER" ]; then
+              echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF' (branch exists but has no ECR image)"
+              emit build-from-base-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
+            else
+              echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+              emit gromit-default "" false ""
             fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
@@ -895,54 +889,28 @@ jobs:
               "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
               | jq -r '.[0].number // empty' 2>/dev/null || true)
 
-            if [ -n "$DASH_PR" ] && aws ecr describe-images \
-              --repository-name tyk-analytics \
-              --image-ids imageTag=pr-${DASH_PR} \
-              --region eu-central-1 > /dev/null 2>&1; then
-              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
-              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"
+              emit analytics-pr-image "${REGISTRY}/tyk-analytics:pr-${DASH_PR}" false "$BRANCH"
             else
-              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
-              echo "    → No open tyk-analytics PR image found for the branch"
-              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH' (no open tyk-analytics PR image)"
+              emit build-from-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BRANCH"
             fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
-            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
-            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
-            echo "    → Will update gateway ref to $COMMIT_SHA"
-            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-            echo "strategy=build-required" >> $GITHUB_OUTPUT
+            echo "🔨 Strategy: Build dashboard from '$BASE_REF' with gateway ref $COMMIT_SHA (PR has relevant package changes)"
+            emit build-required "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
 
           # Strategy 2b: PR image exists and no relevant changes → reuse existing image
           elif [ "$IMAGE_EXISTS" = "true" ]; then
-            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
-            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+            echo "🐳 Strategy: Reuse existing PR image tyk-analytics:${IMAGE_TAG} (no relevant package changes in PR)"
+            emit reuse-pr-image "${REGISTRY}/tyk-analytics:${IMAGE_TAG}" false ""
 
           # Strategy 3: Fallback to gromit default
           else
-            echo "ℹ️ Strategy: Use gromit default"
-            echo "    → No matching branch, no existing PR image, no relevant changes"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            echo "ℹ️ Strategy: Use gromit default (no matching branch, PR image, or relevant changes)"
+            emit gromit-default "" false ""
           fi
 
           echo "=================================="

--- a/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
@@ -777,10 +777,18 @@ jobs:
             exit 0
           fi
 
-          BRANCH=${HEAD_REF##*/}
+          BRANCH="$HEAD_REF"
           echo "Checking for branch: $BRANCH in tyk-analytics"
 
-          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+          if ! REMOTE_REF=$(git ls-remote \
+            --heads \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" \
+            "refs/heads/$BRANCH"); then
+            echo "::error::Unable to query tyk-analytics; check GitHub App authentication and repository permissions"
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_REF" ]; then
             echo "✓ Branch '$BRANCH' exists in tyk-analytics"
             echo "branch_exists=true" >> $GITHUB_OUTPUT
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
@@ -829,6 +837,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
           ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -846,12 +855,31 @@ jobs:
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
             if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-              echo "    → Base branch exists in tyk-analytics, using it directly"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              if aws ecr describe-images \
+                --repository-name tyk-analytics \
+                --image-ids imageTag=${BASE_REF} \
+                --region eu-central-1 > /dev/null 2>&1; then
+                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+                echo "    → Base branch exists in tyk-analytics, using it directly"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              elif [ -n "$PR_NUMBER" ]; then
+                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
+                echo "    → Branch exists in tyk-analytics but has no ECR image"
+                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+                echo "needs_build=true" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
+              else
+                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+                echo "dashboard_image=" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=" >> $GITHUB_OUTPUT
+                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              fi
             else
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
               echo "    → Falling back to gromit default"
@@ -861,14 +889,31 @@ jobs:
               echo "strategy=gromit-default" >> $GITHUB_OUTPUT
             fi
 
-          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
-            echo "    → No override needed, gromit will handle it"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
+              | jq -r '.[0].number // empty' 2>/dev/null || true)
+
+            if [ -n "$DASH_PR" ] && aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=pr-${DASH_PR} \
+              --region eu-central-1 > /dev/null 2>&1; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
+              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            else
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
+              echo "    → No open tyk-analytics PR image found for the branch"
+              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then

--- a/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
@@ -885,9 +885,13 @@ jobs:
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
-              | jq -r '.[0].number // empty' 2>/dev/null || true)
+            # Find the tyk-analytics PR for the branch by matching its head SHA
+            # against refs/pull/*/head; needs only repository read access
+            TA_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git"
+            BRANCH_SHA=$(git ls-remote --heads "$TA_REMOTE" "refs/heads/$BRANCH" | cut -f1 || true)
+            DASH_PR=$(git ls-remote "$TA_REMOTE" 'refs/pull/*/head' 2>/dev/null \
+              | awk -v sha="$BRANCH_SHA" '$1 == sha { split($2, r, "/"); print r[3] }' \
+              | sort -n | tail -1 || true)
 
             if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
               echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"

--- a/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
@@ -852,41 +852,35 @@ jobs:
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
+          # emit <strategy> <dashboard_image> <needs_build> <dashboard_branch>
+          emit() {
+            echo "strategy=$1" >> $GITHUB_OUTPUT
+            echo "dashboard_image=$2" >> $GITHUB_OUTPUT
+            echo "needs_build=$3" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$4" >> $GITHUB_OUTPUT
+          }
+
+          dash_image_exists() {
+            aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=$1 \
+              --region eu-central-1 > /dev/null 2>&1
+          }
+
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              if aws ecr describe-images \
-                --repository-name tyk-analytics \
-                --image-ids imageTag=${BASE_REF} \
-                --region eu-central-1 > /dev/null 2>&1; then
-                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-                echo "    → Base branch exists in tyk-analytics, using it directly"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
-              elif [ -n "$PR_NUMBER" ]; then
-                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
-                echo "    → Branch exists in tyk-analytics but has no ECR image"
-                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-                echo "needs_build=true" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
-              else
-                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
-                echo "dashboard_image=" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=" >> $GITHUB_OUTPUT
-                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
-              echo "    → Falling back to gromit default"
-              echo "dashboard_image=" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=" >> $GITHUB_OUTPUT
-              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              emit gromit-default "" false ""
+            elif dash_image_exists "$BASE_REF"; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              emit release-branch-match "${REGISTRY}/tyk-analytics:${BASE_REF}" false "$BASE_REF"
+            elif [ -n "$PR_NUMBER" ]; then
+              echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF' (branch exists but has no ECR image)"
+              emit build-from-base-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
+            else
+              echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+              emit gromit-default "" false ""
             fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
@@ -895,54 +889,28 @@ jobs:
               "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
               | jq -r '.[0].number // empty' 2>/dev/null || true)
 
-            if [ -n "$DASH_PR" ] && aws ecr describe-images \
-              --repository-name tyk-analytics \
-              --image-ids imageTag=pr-${DASH_PR} \
-              --region eu-central-1 > /dev/null 2>&1; then
-              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
-              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"
+              emit analytics-pr-image "${REGISTRY}/tyk-analytics:pr-${DASH_PR}" false "$BRANCH"
             else
-              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
-              echo "    → No open tyk-analytics PR image found for the branch"
-              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH' (no open tyk-analytics PR image)"
+              emit build-from-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BRANCH"
             fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
-            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
-            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
-            echo "    → Will update gateway ref to $COMMIT_SHA"
-            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-            echo "strategy=build-required" >> $GITHUB_OUTPUT
+            echo "🔨 Strategy: Build dashboard from '$BASE_REF' with gateway ref $COMMIT_SHA (PR has relevant package changes)"
+            emit build-required "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
 
           # Strategy 2b: PR image exists and no relevant changes → reuse existing image
           elif [ "$IMAGE_EXISTS" = "true" ]; then
-            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
-            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+            echo "🐳 Strategy: Reuse existing PR image tyk-analytics:${IMAGE_TAG} (no relevant package changes in PR)"
+            emit reuse-pr-image "${REGISTRY}/tyk-analytics:${IMAGE_TAG}" false ""
 
           # Strategy 3: Fallback to gromit default
           else
-            echo "ℹ️ Strategy: Use gromit default"
-            echo "    → No matching branch, no existing PR image, no relevant changes"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            echo "ℹ️ Strategy: Use gromit default (no matching branch, PR image, or relevant changes)"
+            emit gromit-default "" false ""
           fi
 
           echo "=================================="

--- a/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
@@ -777,10 +777,18 @@ jobs:
             exit 0
           fi
 
-          BRANCH=${HEAD_REF##*/}
+          BRANCH="$HEAD_REF"
           echo "Checking for branch: $BRANCH in tyk-analytics"
 
-          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+          if ! REMOTE_REF=$(git ls-remote \
+            --heads \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" \
+            "refs/heads/$BRANCH"); then
+            echo "::error::Unable to query tyk-analytics; check GitHub App authentication and repository permissions"
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_REF" ]; then
             echo "✓ Branch '$BRANCH' exists in tyk-analytics"
             echo "branch_exists=true" >> $GITHUB_OUTPUT
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
@@ -829,6 +837,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
           ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -846,12 +855,31 @@ jobs:
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
             if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-              echo "    → Base branch exists in tyk-analytics, using it directly"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              if aws ecr describe-images \
+                --repository-name tyk-analytics \
+                --image-ids imageTag=${BASE_REF} \
+                --region eu-central-1 > /dev/null 2>&1; then
+                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+                echo "    → Base branch exists in tyk-analytics, using it directly"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              elif [ -n "$PR_NUMBER" ]; then
+                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
+                echo "    → Branch exists in tyk-analytics but has no ECR image"
+                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+                echo "needs_build=true" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
+              else
+                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+                echo "dashboard_image=" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=" >> $GITHUB_OUTPUT
+                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              fi
             else
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
               echo "    → Falling back to gromit default"
@@ -861,14 +889,31 @@ jobs:
               echo "strategy=gromit-default" >> $GITHUB_OUTPUT
             fi
 
-          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
-            echo "    → No override needed, gromit will handle it"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
+              | jq -r '.[0].number // empty' 2>/dev/null || true)
+
+            if [ -n "$DASH_PR" ] && aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=pr-${DASH_PR} \
+              --region eu-central-1 > /dev/null 2>&1; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
+              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            else
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
+              echo "    → No open tyk-analytics PR image found for the branch"
+              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then

--- a/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
@@ -885,9 +885,13 @@ jobs:
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
-              | jq -r '.[0].number // empty' 2>/dev/null || true)
+            # Find the tyk-analytics PR for the branch by matching its head SHA
+            # against refs/pull/*/head; needs only repository read access
+            TA_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git"
+            BRANCH_SHA=$(git ls-remote --heads "$TA_REMOTE" "refs/heads/$BRANCH" | cut -f1 || true)
+            DASH_PR=$(git ls-remote "$TA_REMOTE" 'refs/pull/*/head' 2>/dev/null \
+              | awk -v sha="$BRANCH_SHA" '$1 == sha { split($2, r, "/"); print r[3] }' \
+              | sort -n | tail -1 || true)
 
             if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
               echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"

--- a/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
@@ -852,41 +852,35 @@ jobs:
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
+          # emit <strategy> <dashboard_image> <needs_build> <dashboard_branch>
+          emit() {
+            echo "strategy=$1" >> $GITHUB_OUTPUT
+            echo "dashboard_image=$2" >> $GITHUB_OUTPUT
+            echo "needs_build=$3" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$4" >> $GITHUB_OUTPUT
+          }
+
+          dash_image_exists() {
+            aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=$1 \
+              --region eu-central-1 > /dev/null 2>&1
+          }
+
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              if aws ecr describe-images \
-                --repository-name tyk-analytics \
-                --image-ids imageTag=${BASE_REF} \
-                --region eu-central-1 > /dev/null 2>&1; then
-                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-                echo "    → Base branch exists in tyk-analytics, using it directly"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
-              elif [ -n "$PR_NUMBER" ]; then
-                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
-                echo "    → Branch exists in tyk-analytics but has no ECR image"
-                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-                echo "needs_build=true" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
-              else
-                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
-                echo "dashboard_image=" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=" >> $GITHUB_OUTPUT
-                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
-              echo "    → Falling back to gromit default"
-              echo "dashboard_image=" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=" >> $GITHUB_OUTPUT
-              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              emit gromit-default "" false ""
+            elif dash_image_exists "$BASE_REF"; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              emit release-branch-match "${REGISTRY}/tyk-analytics:${BASE_REF}" false "$BASE_REF"
+            elif [ -n "$PR_NUMBER" ]; then
+              echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF' (branch exists but has no ECR image)"
+              emit build-from-base-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
+            else
+              echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+              emit gromit-default "" false ""
             fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
@@ -895,54 +889,28 @@ jobs:
               "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
               | jq -r '.[0].number // empty' 2>/dev/null || true)
 
-            if [ -n "$DASH_PR" ] && aws ecr describe-images \
-              --repository-name tyk-analytics \
-              --image-ids imageTag=pr-${DASH_PR} \
-              --region eu-central-1 > /dev/null 2>&1; then
-              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
-              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"
+              emit analytics-pr-image "${REGISTRY}/tyk-analytics:pr-${DASH_PR}" false "$BRANCH"
             else
-              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
-              echo "    → No open tyk-analytics PR image found for the branch"
-              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH' (no open tyk-analytics PR image)"
+              emit build-from-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BRANCH"
             fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
-            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
-            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
-            echo "    → Will update gateway ref to $COMMIT_SHA"
-            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-            echo "strategy=build-required" >> $GITHUB_OUTPUT
+            echo "🔨 Strategy: Build dashboard from '$BASE_REF' with gateway ref $COMMIT_SHA (PR has relevant package changes)"
+            emit build-required "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
 
           # Strategy 2b: PR image exists and no relevant changes → reuse existing image
           elif [ "$IMAGE_EXISTS" = "true" ]; then
-            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
-            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+            echo "🐳 Strategy: Reuse existing PR image tyk-analytics:${IMAGE_TAG} (no relevant package changes in PR)"
+            emit reuse-pr-image "${REGISTRY}/tyk-analytics:${IMAGE_TAG}" false ""
 
           # Strategy 3: Fallback to gromit default
           else
-            echo "ℹ️ Strategy: Use gromit default"
-            echo "    → No matching branch, no existing PR image, no relevant changes"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            echo "ℹ️ Strategy: Use gromit default (no matching branch, PR image, or relevant changes)"
+            emit gromit-default "" false ""
           fi
 
           echo "=================================="

--- a/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
@@ -777,10 +777,18 @@ jobs:
             exit 0
           fi
 
-          BRANCH=${HEAD_REF##*/}
+          BRANCH="$HEAD_REF"
           echo "Checking for branch: $BRANCH in tyk-analytics"
 
-          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+          if ! REMOTE_REF=$(git ls-remote \
+            --heads \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" \
+            "refs/heads/$BRANCH"); then
+            echo "::error::Unable to query tyk-analytics; check GitHub App authentication and repository permissions"
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_REF" ]; then
             echo "✓ Branch '$BRANCH' exists in tyk-analytics"
             echo "branch_exists=true" >> $GITHUB_OUTPUT
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
@@ -829,6 +837,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
           ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -846,12 +855,31 @@ jobs:
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
             if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-              echo "    → Base branch exists in tyk-analytics, using it directly"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              if aws ecr describe-images \
+                --repository-name tyk-analytics \
+                --image-ids imageTag=${BASE_REF} \
+                --region eu-central-1 > /dev/null 2>&1; then
+                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+                echo "    → Base branch exists in tyk-analytics, using it directly"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              elif [ -n "$PR_NUMBER" ]; then
+                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
+                echo "    → Branch exists in tyk-analytics but has no ECR image"
+                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+                echo "needs_build=true" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
+              else
+                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+                echo "dashboard_image=" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=" >> $GITHUB_OUTPUT
+                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              fi
             else
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
               echo "    → Falling back to gromit default"
@@ -861,14 +889,31 @@ jobs:
               echo "strategy=gromit-default" >> $GITHUB_OUTPUT
             fi
 
-          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
-            echo "    → No override needed, gromit will handle it"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
+              | jq -r '.[0].number // empty' 2>/dev/null || true)
+
+            if [ -n "$DASH_PR" ] && aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=pr-${DASH_PR} \
+              --region eu-central-1 > /dev/null 2>&1; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
+              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            else
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
+              echo "    → No open tyk-analytics PR image found for the branch"
+              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then

--- a/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
@@ -885,9 +885,13 @@ jobs:
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
-              | jq -r '.[0].number // empty' 2>/dev/null || true)
+            # Find the tyk-analytics PR for the branch by matching its head SHA
+            # against refs/pull/*/head; needs only repository read access
+            TA_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git"
+            BRANCH_SHA=$(git ls-remote --heads "$TA_REMOTE" "refs/heads/$BRANCH" | cut -f1 || true)
+            DASH_PR=$(git ls-remote "$TA_REMOTE" 'refs/pull/*/head' 2>/dev/null \
+              | awk -v sha="$BRANCH_SHA" '$1 == sha { split($2, r, "/"); print r[3] }' \
+              | sort -n | tail -1 || true)
 
             if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
               echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"

--- a/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
@@ -852,41 +852,35 @@ jobs:
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
+          # emit <strategy> <dashboard_image> <needs_build> <dashboard_branch>
+          emit() {
+            echo "strategy=$1" >> $GITHUB_OUTPUT
+            echo "dashboard_image=$2" >> $GITHUB_OUTPUT
+            echo "needs_build=$3" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$4" >> $GITHUB_OUTPUT
+          }
+
+          dash_image_exists() {
+            aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=$1 \
+              --region eu-central-1 > /dev/null 2>&1
+          }
+
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              if aws ecr describe-images \
-                --repository-name tyk-analytics \
-                --image-ids imageTag=${BASE_REF} \
-                --region eu-central-1 > /dev/null 2>&1; then
-                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-                echo "    → Base branch exists in tyk-analytics, using it directly"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
-              elif [ -n "$PR_NUMBER" ]; then
-                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
-                echo "    → Branch exists in tyk-analytics but has no ECR image"
-                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-                echo "needs_build=true" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
-              else
-                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
-                echo "dashboard_image=" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=" >> $GITHUB_OUTPUT
-                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
-              echo "    → Falling back to gromit default"
-              echo "dashboard_image=" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=" >> $GITHUB_OUTPUT
-              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              emit gromit-default "" false ""
+            elif dash_image_exists "$BASE_REF"; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              emit release-branch-match "${REGISTRY}/tyk-analytics:${BASE_REF}" false "$BASE_REF"
+            elif [ -n "$PR_NUMBER" ]; then
+              echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF' (branch exists but has no ECR image)"
+              emit build-from-base-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
+            else
+              echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+              emit gromit-default "" false ""
             fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
@@ -895,54 +889,28 @@ jobs:
               "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
               | jq -r '.[0].number // empty' 2>/dev/null || true)
 
-            if [ -n "$DASH_PR" ] && aws ecr describe-images \
-              --repository-name tyk-analytics \
-              --image-ids imageTag=pr-${DASH_PR} \
-              --region eu-central-1 > /dev/null 2>&1; then
-              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
-              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"
+              emit analytics-pr-image "${REGISTRY}/tyk-analytics:pr-${DASH_PR}" false "$BRANCH"
             else
-              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
-              echo "    → No open tyk-analytics PR image found for the branch"
-              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH' (no open tyk-analytics PR image)"
+              emit build-from-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BRANCH"
             fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
-            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
-            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
-            echo "    → Will update gateway ref to $COMMIT_SHA"
-            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-            echo "strategy=build-required" >> $GITHUB_OUTPUT
+            echo "🔨 Strategy: Build dashboard from '$BASE_REF' with gateway ref $COMMIT_SHA (PR has relevant package changes)"
+            emit build-required "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
 
           # Strategy 2b: PR image exists and no relevant changes → reuse existing image
           elif [ "$IMAGE_EXISTS" = "true" ]; then
-            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
-            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+            echo "🐳 Strategy: Reuse existing PR image tyk-analytics:${IMAGE_TAG} (no relevant package changes in PR)"
+            emit reuse-pr-image "${REGISTRY}/tyk-analytics:${IMAGE_TAG}" false ""
 
           # Strategy 3: Fallback to gromit default
           else
-            echo "ℹ️ Strategy: Use gromit default"
-            echo "    → No matching branch, no existing PR image, no relevant changes"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            echo "ℹ️ Strategy: Use gromit default (no matching branch, PR image, or relevant changes)"
+            emit gromit-default "" false ""
           fi
 
           echo "=================================="

--- a/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
@@ -777,10 +777,18 @@ jobs:
             exit 0
           fi
 
-          BRANCH=${HEAD_REF##*/}
+          BRANCH="$HEAD_REF"
           echo "Checking for branch: $BRANCH in tyk-analytics"
 
-          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+          if ! REMOTE_REF=$(git ls-remote \
+            --heads \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" \
+            "refs/heads/$BRANCH"); then
+            echo "::error::Unable to query tyk-analytics; check GitHub App authentication and repository permissions"
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_REF" ]; then
             echo "✓ Branch '$BRANCH' exists in tyk-analytics"
             echo "branch_exists=true" >> $GITHUB_OUTPUT
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
@@ -829,6 +837,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
           ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -846,12 +855,31 @@ jobs:
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
             if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-              echo "    → Base branch exists in tyk-analytics, using it directly"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              if aws ecr describe-images \
+                --repository-name tyk-analytics \
+                --image-ids imageTag=${BASE_REF} \
+                --region eu-central-1 > /dev/null 2>&1; then
+                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+                echo "    → Base branch exists in tyk-analytics, using it directly"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              elif [ -n "$PR_NUMBER" ]; then
+                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
+                echo "    → Branch exists in tyk-analytics but has no ECR image"
+                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+                echo "needs_build=true" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
+              else
+                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+                echo "dashboard_image=" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=" >> $GITHUB_OUTPUT
+                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              fi
             else
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
               echo "    → Falling back to gromit default"
@@ -861,14 +889,31 @@ jobs:
               echo "strategy=gromit-default" >> $GITHUB_OUTPUT
             fi
 
-          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
-            echo "    → No override needed, gromit will handle it"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
+              | jq -r '.[0].number // empty' 2>/dev/null || true)
+
+            if [ -n "$DASH_PR" ] && aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=pr-${DASH_PR} \
+              --region eu-central-1 > /dev/null 2>&1; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
+              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            else
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
+              echo "    → No open tyk-analytics PR image found for the branch"
+              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then

--- a/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
@@ -885,9 +885,13 @@ jobs:
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
-              | jq -r '.[0].number // empty' 2>/dev/null || true)
+            # Find the tyk-analytics PR for the branch by matching its head SHA
+            # against refs/pull/*/head; needs only repository read access
+            TA_REMOTE="https://x-access-token:${GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git"
+            BRANCH_SHA=$(git ls-remote --heads "$TA_REMOTE" "refs/heads/$BRANCH" | cut -f1 || true)
+            DASH_PR=$(git ls-remote "$TA_REMOTE" 'refs/pull/*/head' 2>/dev/null \
+              | awk -v sha="$BRANCH_SHA" '$1 == sha { split($2, r, "/"); print r[3] }' \
+              | sort -n | tail -1 || true)
 
             if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
               echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"

--- a/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
@@ -852,41 +852,35 @@ jobs:
           echo "Has relevant changes in PR: $HAS_RELEVANT_CHANGES"
           echo "=================================="
 
+          # emit <strategy> <dashboard_image> <needs_build> <dashboard_branch>
+          emit() {
+            echo "strategy=$1" >> $GITHUB_OUTPUT
+            echo "dashboard_image=$2" >> $GITHUB_OUTPUT
+            echo "needs_build=$3" >> $GITHUB_OUTPUT
+            echo "dashboard_branch=$4" >> $GITHUB_OUTPUT
+          }
+
+          dash_image_exists() {
+            aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=$1 \
+              --region eu-central-1 > /dev/null 2>&1
+          }
+
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
-            if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              if aws ecr describe-images \
-                --repository-name tyk-analytics \
-                --image-ids imageTag=${BASE_REF} \
-                --region eu-central-1 > /dev/null 2>&1; then
-                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-                echo "    → Base branch exists in tyk-analytics, using it directly"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
-              elif [ -n "$PR_NUMBER" ]; then
-                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
-                echo "    → Branch exists in tyk-analytics but has no ECR image"
-                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-                echo "needs_build=true" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
-              else
-                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
-                echo "dashboard_image=" >> $GITHUB_OUTPUT
-                echo "needs_build=false" >> $GITHUB_OUTPUT
-                echo "dashboard_branch=" >> $GITHUB_OUTPUT
-                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
-              echo "    → Falling back to gromit default"
-              echo "dashboard_image=" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=" >> $GITHUB_OUTPUT
-              echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              emit gromit-default "" false ""
+            elif dash_image_exists "$BASE_REF"; then
+              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+              emit release-branch-match "${REGISTRY}/tyk-analytics:${BASE_REF}" false "$BASE_REF"
+            elif [ -n "$PR_NUMBER" ]; then
+              echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF' (branch exists but has no ECR image)"
+              emit build-from-base-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
+            else
+              echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+              emit gromit-default "" false ""
             fi
 
           # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
@@ -895,54 +889,28 @@ jobs:
               "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
               | jq -r '.[0].number // empty' 2>/dev/null || true)
 
-            if [ -n "$DASH_PR" ] && aws ecr describe-images \
-              --repository-name tyk-analytics \
-              --image-ids imageTag=pr-${DASH_PR} \
-              --region eu-central-1 > /dev/null 2>&1; then
-              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
-              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            if [ -n "$DASH_PR" ] && dash_image_exists "pr-${DASH_PR}"; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image (tyk-analytics:pr-${DASH_PR}) for matching branch '$BRANCH'"
+              emit analytics-pr-image "${REGISTRY}/tyk-analytics:pr-${DASH_PR}" false "$BRANCH"
             else
-              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
-              echo "    → No open tyk-analytics PR image found for the branch"
-              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH' (no open tyk-analytics PR image)"
+              emit build-from-branch "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BRANCH"
             fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then
-            PR_IMAGE_TAG="tyk-${PR_NUMBER}"
-            echo "🔨 Strategy: Build dashboard (PR has relevant package changes)"
-            echo "    → Will update gateway ref to $COMMIT_SHA"
-            echo "    → Will push to: ${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${PR_IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-            echo "strategy=build-required" >> $GITHUB_OUTPUT
+            echo "🔨 Strategy: Build dashboard from '$BASE_REF' with gateway ref $COMMIT_SHA (PR has relevant package changes)"
+            emit build-required "${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" true "$BASE_REF"
 
           # Strategy 2b: PR image exists and no relevant changes → reuse existing image
           elif [ "$IMAGE_EXISTS" = "true" ]; then
-            echo "🐳 Strategy: Reuse existing PR image (no relevant package changes in PR)"
-            echo "    → Image: ${REGISTRY}/tyk-analytics:${IMAGE_TAG}"
-            echo "dashboard_image=${REGISTRY}/tyk-analytics:${IMAGE_TAG}" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=reuse-pr-image" >> $GITHUB_OUTPUT
+            echo "🐳 Strategy: Reuse existing PR image tyk-analytics:${IMAGE_TAG} (no relevant package changes in PR)"
+            emit reuse-pr-image "${REGISTRY}/tyk-analytics:${IMAGE_TAG}" false ""
 
           # Strategy 3: Fallback to gromit default
           else
-            echo "ℹ️ Strategy: Use gromit default"
-            echo "    → No matching branch, no existing PR image, no relevant changes"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+            echo "ℹ️ Strategy: Use gromit default (no matching branch, PR image, or relevant changes)"
+            emit gromit-default "" false ""
           fi
 
           echo "=================================="

--- a/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
@@ -777,10 +777,18 @@ jobs:
             exit 0
           fi
 
-          BRANCH=${HEAD_REF##*/}
+          BRANCH="$HEAD_REF"
           echo "Checking for branch: $BRANCH in tyk-analytics"
 
-          if git ls-remote --heads https://$GITHUB_TOKEN@github.com/TykTechnologies/tyk-analytics.git refs/heads/$BRANCH | grep -q .; then
+          if ! REMOTE_REF=$(git ls-remote \
+            --heads \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" \
+            "refs/heads/$BRANCH"); then
+            echo "::error::Unable to query tyk-analytics; check GitHub App authentication and repository permissions"
+            exit 1
+          fi
+
+          if [ -n "$REMOTE_REF" ]; then
             echo "✓ Branch '$BRANCH' exists in tyk-analytics"
             echo "branch_exists=true" >> $GITHUB_OUTPUT
             echo "branch=$BRANCH" >> $GITHUB_OUTPUT
@@ -829,6 +837,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HAS_RELEVANT_CHANGES: ${{ steps.check_changes.outputs.has_relevant_changes }}
           ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "=================================="
           echo "📊 Dashboard Image Resolution"
@@ -846,12 +855,31 @@ jobs:
           # For non-master base branches, check if the same branch exists in tyk-analytics
           if [ "$BASE_REF" != "master" ]; then
             if git ls-remote --exit-code --heads "https://x-access-token:${ORG_GH_TOKEN}@github.com/TykTechnologies/tyk-analytics.git" "refs/heads/$BASE_REF" > /dev/null 2>&1; then
-              echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
-              echo "    → Base branch exists in tyk-analytics, using it directly"
-              echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-              echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
-              echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              if aws ecr describe-images \
+                --repository-name tyk-analytics \
+                --image-ids imageTag=${BASE_REF} \
+                --region eu-central-1 > /dev/null 2>&1; then
+                echo "📋 Strategy: Use release branch '$BASE_REF' from tyk-analytics"
+                echo "    → Base branch exists in tyk-analytics, using it directly"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:${BASE_REF}" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=release-branch-match" >> $GITHUB_OUTPUT
+              elif [ -n "$PR_NUMBER" ]; then
+                echo "🔨 Strategy: Build dashboard from base branch '$BASE_REF'"
+                echo "    → Branch exists in tyk-analytics but has no ECR image"
+                echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+                echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+                echo "needs_build=true" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=$BASE_REF" >> $GITHUB_OUTPUT
+                echo "strategy=build-from-base-branch" >> $GITHUB_OUTPUT
+              else
+                echo "ℹ️ Strategy: Use gromit default (no ECR image for '$BASE_REF' and not a PR)"
+                echo "dashboard_image=" >> $GITHUB_OUTPUT
+                echo "needs_build=false" >> $GITHUB_OUTPUT
+                echo "dashboard_branch=" >> $GITHUB_OUTPUT
+                echo "strategy=gromit-default" >> $GITHUB_OUTPUT
+              fi
             else
               echo "ℹ️ Strategy: Use gromit default (base branch '$BASE_REF' not found in tyk-analytics)"
               echo "    → Falling back to gromit default"
@@ -861,14 +889,31 @@ jobs:
               echo "strategy=gromit-default" >> $GITHUB_OUTPUT
             fi
 
-          # Strategy 1: Matching branch exists in tyk-analytics → use gromit
+          # Strategy 1: Matching branch exists in tyk-analytics → use its PR image, or build from it
           elif [ "$BRANCH_EXISTS" = "true" ]; then
-            echo "📋 Strategy: Use matching branch '$BRANCH' via gromit"
-            echo "    → No override needed, gromit will handle it"
-            echo "dashboard_image=" >> $GITHUB_OUTPUT
-            echo "needs_build=false" >> $GITHUB_OUTPUT
-            echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
-            echo "strategy=gromit-branch" >> $GITHUB_OUTPUT
+            DASH_PR=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/TykTechnologies/tyk-analytics/pulls?head=TykTechnologies:${BRANCH}&state=open" \
+              | jq -r '.[0].number // empty' 2>/dev/null || true)
+
+            if [ -n "$DASH_PR" ] && aws ecr describe-images \
+              --repository-name tyk-analytics \
+              --image-ids imageTag=pr-${DASH_PR} \
+              --region eu-central-1 > /dev/null 2>&1; then
+              echo "📋 Strategy: Use tyk-analytics PR #${DASH_PR} image for matching branch '$BRANCH'"
+              echo "    → Image: ${REGISTRY}/tyk-analytics:pr-${DASH_PR}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:pr-${DASH_PR}" >> $GITHUB_OUTPUT
+              echo "needs_build=false" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=analytics-pr-image" >> $GITHUB_OUTPUT
+            else
+              echo "🔨 Strategy: Build dashboard from matching branch '$BRANCH'"
+              echo "    → No open tyk-analytics PR image found for the branch"
+              echo "    → Will push to: ${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}"
+              echo "dashboard_image=${REGISTRY}/tyk-analytics:tyk-${PR_NUMBER}" >> $GITHUB_OUTPUT
+              echo "needs_build=true" >> $GITHUB_OUTPUT
+              echo "dashboard_branch=$BRANCH" >> $GITHUB_OUTPUT
+              echo "strategy=build-from-branch" >> $GITHUB_OUTPUT
+            fi
 
           # Strategy 2a: PR has relevant changes → build new image
           elif [ "$HAS_RELEVANT_CHANGES" = "true" ]; then


### PR DESCRIPTION
## Problem

Gateway PRs with a same-named branch in tyk-analytics no longer test against that branch's dashboard. Example: [tyk#8262](https://github.com/TykTechnologies/tyk/pull/8262) api-tests run a master-built dashboard, so its new cross-repo tests fail, while [tyk-analytics#5970](https://github.com/TykTechnologies/tyk-analytics/pull/5970) can't go green either — a chicken-and-egg on merging.

Three defects in `tyk-dashboard-resolver.gotmpl`:

1. **Branch detection silently broken.** The `check_branch` step authenticates `git ls-remote` with a GitHub App installation token in PAT-style URL form (`https://$TOKEN@github.com/...`), which GitHub rejects for app tokens. The failure is swallowed by `| grep -q .`, so `branch_exists=false` on every run (verified in runs from May 29 through Jul 29). Introduced when the step migrated off `ORG_GH_TOKEN` — same bug class fixed in tyk-analytics in April (`ce1f63e31`).
2. **Branch name mangling.** `BRANCH=${HEAD_REF##*/}` strips path segments, so `feat/x/y`-style branches can never match (`github.head_ref` has no `refs/heads/` prefix to strip).
3. **Matching-branch strategy is a no-op.** It emits an empty `dashboard_image` "for gromit to handle", but gromit's `policy match` resolves siblings by base-ref tag only (`master` for master-based PRs), so api-tests always get `tyk-analytics:master`. Verified: [tyk run 30496446177](https://github.com/TykTechnologies/tyk/actions/runs/30496446177) has the auth fix, detects the branch, and still runs a master dashboard.

## Fix

- `check_branch`: use `x-access-token:` auth and fail loudly on query errors (matches the fix already applied on tyk#8262, so the next sync converges with it rather than reverting it); use the full head ref.
- Matching-branch strategy: look up the open tyk-analytics PR for the branch and use its already-pushed `pr-<N>` ECR image; if none exists, build the dashboard from the matching branch via the existing `build-dashboard-image` job (which already supports `ref:`).
- Release-branch match: verify the branch-named ECR image exists before referencing it — previously a missing image crashed `docker compose` with `manifest unknown` ([tyk run 28873305683](https://github.com/TykTechnologies/tyk/actions/runs/28873305683)); on PRs, fall back to building from that branch.

Golden files regenerated with `make update-golden`; `TestGoldenRender` passes. (`TestNonTrivialDiff` fails on a clean checkout locally — pre-existing, unrelated.)

## Note

The dashboard repo side (tyk-analytics api-tests getting a matching *gateway* image) has no resolver at all and needs a separate follow-up: a `gateway_image` input on the shared `env-up` action plus a mirror resolve step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)