### PR TITLE
TT-17849: fix nightly-e2e api workflow_dispatch config gap

### DIFF
--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -25,6 +25,7 @@ level: # testsuites
         level: # trigger
           workflow_dispatch:
             level: # repo
+              tyk-analytics:
           pull_request:
             level: # repo
               tyk:
@@ -93,6 +94,7 @@ level: # testsuites
                     gwdash: "master"
           workflow_dispatch:
             level: # repo
+              tyk-analytics:
           pull_request:
             level: # repo
               tyk:

--- a/config/tui/test-variations.yml
+++ b/config/tui/test-variations.yml
@@ -25,6 +25,7 @@ level: # testsuites
         level: # trigger
           workflow_dispatch:
             level: # repo
+              tyk-analytics:
           pull_request:
             level: # repo
               tyk:
@@ -92,6 +93,7 @@ level: # testsuites
                     gwdash: "master"
           workflow_dispatch:
             level: # repo
+              tyk-analytics:
           pull_request:
             level: # repo
               tyk:


### PR DESCRIPTION
## Summary
- `test-controller-api` in tyk-analytics's nightly-e2e workflow failed on workflow_dispatch runs (e.g. [run 30623650752](https://github.com/TykTechnologies/tyk-analytics/actions/runs/30623650752/job/91133761809)): it 404s against the TUI static site for `master`, falls back to `default`, which also 404s, and the fallback's HTML body gets written straight into `$GITHUB_OUTPUT`, crashing the job with exit 22.
- Root cause: `config/tui/prod-variations.yml` (and the equivalent `test-variations.yml`) had an **empty repo list** under the `api` testsuite's `workflow_dispatch` trigger for both the `default` and `master` branches, while `pull_request`/`push` list all repos and the `ui` testsuite already lists `tyk-analytics` under `workflow_dispatch`.
- Fix: add `tyk-analytics:` under `api.level.default.level.workflow_dispatch.level` and `api.level.master.level.workflow_dispatch.level` in both variation files, matching the existing `ui` testsuite pattern.

## Test plan
- [x] Ran `go run main.go policy generate-tui --config-dir config/tui --out-dir <tmp>` locally and confirmed `v2/prod-variation/tyk-analytics/{master,default}/workflow_dispatch/api.gho` are now generated with valid `GITHUB_OUTPUT`-format content (previously missing/404).
- [x] `go test ./policy/...` passes.
- [ ] Merging to master auto-redeploys the static TUI site via `pages.yml`; re-run the tyk-analytics nightly-e2e workflow via `workflow_dispatch` after merge to confirm `test-controller-api` succeeds.