### PR TITLE
TT-17868 update Go for portal and pgo-services (tyk-pump, tyk-identit…

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -343,7 +343,7 @@ policy:
           packagename: portal
           binary: dev-portal
           buildpackagename: portal
-          buildenv: 1.25-bookworm
+          buildenv: 1.26-bookworm
           cgo: true
           upgradefromver: 1.0.0
           configfile: portal.conf
@@ -460,7 +460,7 @@ policy:
       features:
         - releng
         - distroless
-      buildenv: 1.25-bookworm
+      buildenv: 1.26-bookworm
       baseimage: debian:trixie-slim
       distrolessbaseimage: static-debian13:nonroot
       repos:

--- a/policy/testdata/golden/portal/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/portal/master/.github/workflows/release.yml
@@ -49,9 +49,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.25-bookworm
+          - 1.26-bookworm
         include:
-          - golang_cross: 1.25-bookworm
+          - golang_cross: 1.26-bookworm
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 1
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -104,7 +104,7 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           mask-password: 'true'
       - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
@@ -181,7 +181,7 @@ jobs:
           -w /go/src/github.com/TykTechnologies/portal                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - name: Install Docker Scout CLI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           mkdir -p ~/.docker/cli-plugins
           curl --proto '=https' --tlsv1.2 -fsSL https://github.com/docker/scout-cli/releases/download/v1.22.0/docker-scout_1.22.0_linux_amd64.tar.gz -o /tmp/scout.tar.gz
@@ -191,7 +191,7 @@ jobs:
           chmod +x ~/.docker/cli-plugins/docker-scout
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -206,7 +206,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -223,7 +223,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -284,7 +284,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -300,7 +300,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -343,7 +343,7 @@ jobs:
           fi
           echo "Success: All layers are uniformly compressed using gzip."
       - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
           if [ -f /tmp/fips-vex.json ]; then
@@ -353,7 +353,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -368,7 +368,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -383,7 +383,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=portal
       - name: Verify compression format for std CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -444,7 +444,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -458,7 +458,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=portal
       - name: Verify compression format for std prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -502,7 +502,7 @@ jobs:
           echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: deb
           retention-days: 1
@@ -512,7 +512,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: rpm
           retention-days: 1

--- a/policy/testdata/golden/tyk-identity-broker/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-identity-broker/master/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.25-bookworm
+          - 1.26-bookworm
         include:
-          - golang_cross: 1.25-bookworm
+          - golang_cross: 1.26-bookworm
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 0
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -106,7 +106,7 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           mask-password: 'true'
       - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
@@ -184,7 +184,7 @@ jobs:
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -199,7 +199,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -214,7 +214,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-identity-broker
       - name: Verify compression format for std CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -276,7 +276,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -290,7 +290,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-identity-broker
       - name: Verify compression format for std prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -334,7 +334,7 @@ jobs:
           echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: deb
           retention-days: 1
@@ -344,7 +344,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: rpm
           retention-days: 1

--- a/policy/testdata/golden/tyk-pump/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-pump/master/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.25-bookworm
+          - 1.26-bookworm
         include:
-          - golang_cross: 1.25-bookworm
+          - golang_cross: 1.26-bookworm
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 0
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -107,7 +107,7 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           mask-password: 'true'
       - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
@@ -184,7 +184,7 @@ jobs:
           -w /go/src/github.com/TykTechnologies/tyk-pump                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - name: Install Docker Scout CLI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           mkdir -p ~/.docker/cli-plugins
           curl --proto '=https' --tlsv1.2 -fsSL https://github.com/docker/scout-cli/releases/download/v1.22.0/docker-scout_1.22.0_linux_amd64.tar.gz -o /tmp/scout.tar.gz
@@ -194,7 +194,7 @@ jobs:
           chmod +x ~/.docker/cli-plugins/docker-scout
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -209,7 +209,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -226,7 +226,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -287,7 +287,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -303,7 +303,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -346,7 +346,7 @@ jobs:
           fi
           echo "Success: All layers are uniformly compressed using gzip."
       - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
           if [ -f /tmp/fips-vex.json ]; then
@@ -356,7 +356,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -371,7 +371,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -386,7 +386,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -448,7 +448,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -462,7 +462,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -506,7 +506,7 @@ jobs:
           echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: deb
           retention-days: 1
@@ -516,7 +516,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: rpm
           retention-days: 1

--- a/policy/testdata/golden/tyk-sink/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-sink/master/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.25-bookworm
+          - 1.26-bookworm
         include:
-          - golang_cross: 1.25-bookworm
+          - golang_cross: 1.26-bookworm
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 0
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -107,7 +107,7 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           mask-password: 'true'
       - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
@@ -184,7 +184,7 @@ jobs:
           -w /go/src/github.com/TykTechnologies/tyk-sink                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - name: Install Docker Scout CLI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           mkdir -p ~/.docker/cli-plugins
           curl --proto '=https' --tlsv1.2 -fsSL https://github.com/docker/scout-cli/releases/download/v1.22.0/docker-scout_1.22.0_linux_amd64.tar.gz -o /tmp/scout.tar.gz
@@ -194,7 +194,7 @@ jobs:
           chmod +x ~/.docker/cli-plugins/docker-scout
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -209,7 +209,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -226,7 +226,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -287,7 +287,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -303,7 +303,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -346,7 +346,7 @@ jobs:
           fi
           echo "Success: All layers are uniformly compressed using gzip."
       - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
           if [ -f /tmp/fips-vex.json ]; then
@@ -356,7 +356,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -371,7 +371,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -386,7 +386,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-sink
       - name: Verify compression format for std CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -447,7 +447,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -461,7 +461,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-sink
       - name: Verify compression format for std prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -505,7 +505,7 @@ jobs:
           echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: deb
           retention-days: 1
@@ -515,7 +515,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: rpm
           retention-days: 1


### PR DESCRIPTION
Upgrading Go to 1.26.

Prior the upgrade the spike proved it should be safe to perform the upgrade.
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17868" title="TT-17868" target="_blank">TT-17868</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | Update Tyk components to Go 1.26 |

Generated at: 2026-08-06 14:36:03

</details>

<!---TykTechnologies/jira-linter ends here-->
