### PR TITLE
TT-17917: build arm64 container images on pull requests

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -360,7 +360,7 @@
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: {{ if has "ai-studio-frontend-build" $r.Branchvals.Features }}"."{{ else }}"dist"{{ end }}
-          platforms: {{`${{ github.event_name == 'pull_request' && 'linux/amd64' || '`}}{{ $bv.GetDockerPlatforms | join "," }}{{`' }}`}}
+          platforms: {{`${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || '`}}{{ $bv.GetDockerPlatforms | join "," }}{{`' }}`}}
           {{- if has "distroless" $r.Branchvals.Features }}
           file: ci/Dockerfile.distroless
           {{- else }}

--- a/policy/testdata/golden/ai-studio/main/.github/workflows/release.yml
+++ b/policy/testdata/golden/ai-studio/main/.github/workflows/release.yml
@@ -273,7 +273,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "."
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.std
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -422,7 +422,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "."
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.std
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/midsommar/main/.github/workflows/release.yml
+++ b/policy/testdata/golden/midsommar/main/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/portal/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/portal/master/.github/workflows/release.yml
@@ -210,7 +210,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -372,7 +372,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-analytics/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/master/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -440,7 +440,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-analytics/release-5.13.1/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.13.1/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -440,7 +440,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-analytics/release-5.13/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.13/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -440,7 +440,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-analytics/release-5.14.0/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.14.0/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -440,7 +440,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-analytics/release-5.14/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.14/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -440,7 +440,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-analytics/release-5.3/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.3/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-analytics/release-5.8.15/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.8.15/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -440,7 +440,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-analytics/release-5.8/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.8/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -440,7 +440,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-identity-broker/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-identity-broker/master/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-pump/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-pump/master/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -375,7 +375,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk-sink/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-sink/master/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -375,7 +375,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/master/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -380,7 +380,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -542,7 +542,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -380,7 +380,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -542,7 +542,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -380,7 +380,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -542,7 +542,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -380,7 +380,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -542,7 +542,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -380,7 +380,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -542,7 +542,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk/release-5.3/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.3/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -380,7 +380,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -542,7 +542,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true

--- a/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
@@ -214,7 +214,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -380,7 +380,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
@@ -542,7 +542,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/s390x' }}
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64,linux/arm64,linux/s390x' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
           outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true


### PR DESCRIPTION
Builds `linux/amd64` and `linux/arm64` images for pull requests. Keeps `s390x` for tag and branch builds only.

The CI image push step in the release template forced pull-request builds to `linux/amd64`. Our production-like environment runs on arm64 nodes, so PR images could not run there. This adds arm64 to PR builds.

- [TT-17917](https://tyktech.atlassian.net/browse/TT-17917)

[TT-17917]: https://tyktech.atlassian.net/browse/TT-17917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ