### PR TITLE
TT-17868 use warp-8x runner for tyk-analytics goreleaser build

### DIFF
--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -10,11 +10,13 @@
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '{{`${{ matrix.golang_cross }}`}}'
-    {{- if eq .Name "tyk-analytics" }}
+    {{- if or (eq .Name "tyk-analytics") (eq .Name "tyk") }}
     runs-on: {{`${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}`}}
-    timeout-minutes: 90
     {{- else }}
     runs-on: {{`${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}`}}
+    {{- end }}
+    {{- if eq .Name "tyk-analytics" }}
+    timeout-minutes: 90
     {{- end }}
     permissions:
       id-token: write   # AWS OIDC JWT

--- a/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
+++ b/policy/templates/releng/.github/workflows/release.yml.d/goreleaser.gotmpl
@@ -10,9 +10,11 @@
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '{{`${{ matrix.golang_cross }}`}}'
-    runs-on: {{`${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}`}}
     {{- if eq .Name "tyk-analytics" }}
+    runs-on: {{`${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}`}}
     timeout-minutes: 90
+    {{- else }}
+    runs-on: {{`${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}`}}
     {{- end }}
     permissions:
       id-token: write   # AWS OIDC JWT

--- a/policy/testdata/golden/tyk-analytics/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/master/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT

--- a/policy/testdata/golden/tyk-analytics/release-5.13.1/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.13.1/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT

--- a/policy/testdata/golden/tyk-analytics/release-5.13/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.13/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT

--- a/policy/testdata/golden/tyk-analytics/release-5.14.0/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.14.0/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT

--- a/policy/testdata/golden/tyk-analytics/release-5.14/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.14/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT

--- a/policy/testdata/golden/tyk-analytics/release-5.3/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.3/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT

--- a/policy/testdata/golden/tyk-analytics/release-5.8.15/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.8.15/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT

--- a/policy/testdata/golden/tyk-analytics/release-5.8/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk-analytics/release-5.8/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     timeout-minutes: 90
     permissions:
       id-token: write # AWS OIDC JWT

--- a/policy/testdata/golden/tyk/master/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/master/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout

--- a/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13.1/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout

--- a/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.13/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout

--- a/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14.0/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout

--- a/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.14/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout

--- a/policy/testdata/golden/tyk/release-5.3/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.3/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout

--- a/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8.15/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout

--- a/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
+++ b/policy/testdata/golden/tyk/release-5.8/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.WARP_RUNNER_8X_X64 || vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout


### PR DESCRIPTION
The 4-core WarpBuild runner was hitting OOM (exit 137) compiling all 6 CGO cross-compile targets (fips/std x amd64/arm64/s390x) for tyk-analytics. Confirmed on tyk-analytics#6056 that an 8-core runner resolves it.

## Description

<!-- Please include a summary of the changes and the motivation/context for this pull request. -->

**Jira Ticket:** [TT-XXXX](https://tyktech.atlassian.net/browse/TT-XXXX)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / documentation / template sync

## Verification & Testing

<!-- Please describe the tests that you ran to verify your changes. -->

- [ ] I have run local unit tests (`go test ./policy/...`) and they passed.
- [ ] I have generated policy outputs locally (`go run . policy gen`) and verified the rendered files.
- [ ] I have verified the changes in target downstream repositories (e.g. `tyk`, `tyk-analytics`).

### Command(s) used for testing:

```bash
# Example: go run . policy gen /tmp/output --repo tyk --branch master
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
