### PR TITLE
TT-17819: protect the dashboard upgrade-test version from pruning

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -716,7 +716,8 @@ pkgs:
       - v2.9.4.3-1
       - v2.9.4.7
       - v2.8.3
-      - v3.0.8 # used in upgrade tests
+      - v3.0.8 # used in upgrade tests on branches not yet re-synced
+      - v3.0.9 # used in upgrade tests
     versioncutoff: v3
   tyk-pump:
     notbackup: false

--- a/config/lint_test.go
+++ b/config/lint_test.go
@@ -127,6 +127,102 @@ func TestConfigRedundancy(t *testing.T) {
 	}
 }
 
+// pkgsAlias maps a policy repo to its packagecloud repo where neither
+// the repo name nor its packagename matches: tyk-sink publishes its
+// packages as tyk-mdcb.
+var pkgsAlias = map[string]string{
+	"tyk-sink": "tyk-mdcb",
+}
+
+// TestUpgradeVersionsProtected keeps the pruning exceptions in sync with
+// the upgrade tests.
+//
+// Every repo's upgradefromver is a version that upgrade tests install
+// from packagecloud, so pruning must never delete it. The protection
+// lives in the pkgs exceptions list, which is maintained by hand and can
+// silently drift when upgradefromver moves: tyk-dashboard bumped to
+// 3.0.9 while the exception still said 3.0.8. That is survivable only
+// while the version cutoff happens to sit below the test version; the
+// moment the cutoff moves, the package is deleted and every upgrade test
+// on every branch fails.
+//
+// This test fails any change where an upgradefromver (repo or branch
+// level) is missing from the corresponding pkgs exceptions list.
+func TestUpgradeVersionsProtected(t *testing.T) {
+	raw, err := os.ReadFile("config.yaml")
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	var doc struct {
+		Policy struct {
+			Groups map[string]map[string]any `yaml:"groups"`
+		} `yaml:"policy"`
+		Pkgs map[string]struct {
+			Exceptions []string `yaml:"exceptions"`
+		} `yaml:"pkgs"`
+	}
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse config.yaml: %v", err)
+	}
+
+	var findings []string
+	for gName, group := range doc.Policy.Groups {
+		repos, _ := group["repos"].(map[string]any)
+		for rName, r := range repos {
+			repo, _ := r.(map[string]any)
+			if repo == nil {
+				continue
+			}
+
+			// versions to protect -> where they were configured
+			versions := make(map[string]string)
+			if v, ok := repo["upgradefromver"]; ok {
+				versions[fmt.Sprintf("%v", v)] = fmt.Sprintf("%s.%s", gName, rName)
+			}
+			branches, _ := repo["branches"].(map[string]any)
+			for bName, b := range branches {
+				branch, _ := b.(map[string]any)
+				if v, ok := branch["upgradefromver"]; branch != nil && ok {
+					versions[fmt.Sprintf("%v", v)] = fmt.Sprintf("%s.%s.branches.%s", gName, rName, bName)
+				}
+			}
+			if len(versions) == 0 {
+				continue
+			}
+
+			// The packagecloud repo is the packagename, unless aliased.
+			pkgsName := rName
+			if pn, ok := repo["packagename"].(string); ok && pn != "" {
+				pkgsName = pn
+			}
+			if alias, ok := pkgsAlias[rName]; ok {
+				pkgsName = alias
+			}
+			pkgsRepo, pruned := doc.Pkgs[pkgsName]
+			if !pruned {
+				// not a pruned repo (e.g. tyk-ai-studio), nothing to protect
+				continue
+			}
+
+			exceptions := make(map[string]bool)
+			for _, e := range pkgsRepo.Exceptions {
+				exceptions[e] = true
+			}
+			for version, where := range versions {
+				if !exceptions["v"+version] {
+					findings = append(findings, fmt.Sprintf(
+						"%s: upgradefromver %s is not in pkgs.%s.exceptions; pruning could delete it and break upgrade tests. Add `- v%s # used in upgrade tests`",
+						where, version, pkgsName, version))
+				}
+			}
+		}
+	}
+
+	for _, f := range findings {
+		t.Errorf("  - %s", f)
+	}
+}
+
 func toStringSet(v any) map[string]bool {
 	set := make(map[string]bool)
 	list, _ := v.([]any)


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the motivation/context for this pull request. -->
```
Adds the missing exception and a lint that fails any change where an
upgradefromver is not protected by its repo's pkgs exceptions, so the
two sections can no longer drift apart silently.
```

**Jira Ticket:** [TT-17819](https://tyktech.atlassian.net/browse/TT-17819)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / documentation / template sync

## Verification & Testing

<!-- Please describe the tests that you ran to verify your changes. -->

- [ ] I have run local unit tests (`go test ./policy/...`) and they passed.
- [ ] I have generated policy outputs locally (`go run . policy gen`) and verified the rendered files.
- [ ] I have verified the changes in target downstream repositories (e.g. `tyk`, `tyk-analytics`).

### Command(s) used for testing:

```bash
# Example: go run . policy gen /tmp/output --repo tyk --branch master
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


[TT-17819]: https://tyktech.atlassian.net/browse/TT-17819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ