### PR TITLE
TT-17641: publish the NG plugin compiler for arm64

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -218,9 +218,32 @@ policy:
               withcxx: "1"
               withgit: "1"
               gatewaytrimpath: "true"
+              # Architectures a plugin can be built FOR. The compiler
+              # cross-compiles these from whatever host it runs on.
               cearchs: amd64,arm64,s390x
               eearchs: amd64,arm64
               fipsarchs: amd64,arm64
+              # Platforms the compiler IMAGE itself is published for -- a
+              # different thing from the archs above, which are what a plugin
+              # can be built for. An amd64 image already cross-compiles arm64
+              # plugins; this is about running the compiler natively on an
+              # arm64 host instead of under emulation.
+              #
+              # Set here rather than per branch on purpose: a branch-level
+              # `plugincompiler:` block REPLACES this one wholesale instead of
+              # merging, so overriding one key there silently resets the DHI
+              # base, customization id and variants to their defaults.
+              imageplatforms: linux/amd64,linux/arm64
+              # Which variant carries the Tier B toolchain gate for the extra
+              # platforms. That gate runs emulated and costs tens of minutes,
+              # and the toolchain it proves is identical across variants, so it
+              # is paid once rather than per variant. Empty would gate them all.
+              extragatevariant: ee
+              # The one platform that gets the full compile-and-load gate.
+              # Every other platform is still built and its toolchain exercised,
+              # but plugin.Open needs a runner of that architecture and the org
+              # has none, so it stays amd64. See the PR for the follow-up.
+              gateplatform: linux/amd64
           # Features common to every tyk branch. Branch entries below only
           # add their genuine extras (features are unioned across levels).
           features:

--- a/policy/plugin_compiler_test.go
+++ b/policy/plugin_compiler_test.go
@@ -684,3 +684,105 @@ func readRenderedFile(t *testing.T, outputDir, name string) string {
 	require.NoError(t, err)
 	return string(contents)
 }
+
+// TestPluginCompilerNGImagePlatforms pins what `imageplatforms` controls. The
+// key is the feature flag for native multi-arch compiler images: with it at its
+// default the render must be byte-for-byte what an amd64-only build always was,
+// and every piece of emulation machinery must appear only when a non-native
+// platform is actually asked for.
+func TestPluginCompilerNGImagePlatforms(t *testing.T) {
+	render := func(t *testing.T, platforms string) string {
+		t.Helper()
+
+		var pol Policies
+		config.LoadConfig("")
+		require.NoError(t, LoadRepoPolicies(&pol))
+
+		repo, err := pol.GetRepoPolicy("tyk")
+		require.NoError(t, err)
+		require.NoError(t, repo.SetBranch("master"))
+
+		ng := repo.Branchvals.PluginCompiler.NextGen
+		ng.ImagePlatforms = platforms
+		repo.Branchvals.PluginCompiler.NextGen = ng
+
+		bundle, err := NewBundle([]string{"plugin-compiler-ng"})
+		require.NoError(t, err)
+
+		outputDir := t.TempDir()
+		_, err = bundle.Render(repo, outputDir, nil)
+		require.NoError(t, err)
+
+		return readRenderedFile(t, outputDir, ".github/workflows/plugin-compiler-ng-build.yml")
+	}
+
+	// Everything below is emulation machinery. None of it may cost an
+	// amd64-only build anything -- notably the go.dev lookup, which would
+	// otherwise make every release depend on a third-party host it has no
+	// reason to contact.
+	armOnly := []string{
+		"setup-qemu-action",
+		"go.dev/dl",
+		"GO_TARBALL_SHA256_ARM64",
+		"Build linux/arm64 NG gate image",   // the per-platform Tier B build
+		"Validate linux/arm64 NG toolchain", // its VALIDATE_ONLY companion
+		"COMPILER_PLATFORM",                 // which pins that companion to the emulated image
+	}
+
+	t.Run("amd64 only is the default and renders no emulation", func(t *testing.T) {
+		workflow := render(t, "")
+
+		for _, marker := range armOnly {
+			assert.NotContains(t, workflow, marker,
+				"an amd64-only image must not carry %q", marker)
+		}
+		assert.NotContains(t, workflow, "linux/arm64,",
+			"no build step may span platforms")
+
+		// `load: true` accepts exactly one platform, so the Tier A gate build
+		// stays single-platform no matter what else is requested.
+		assert.Equal(t, 7, strings.Count(workflow, "platforms: linux/amd64\n"),
+			"expected the base build plus a gate and a push build per variant")
+	})
+
+	t.Run("adding arm64 enables emulation and spans the push", func(t *testing.T) {
+		workflow := render(t, "linux/amd64,linux/arm64")
+
+		for _, marker := range armOnly {
+			assert.Contains(t, workflow, marker,
+				"a multi-platform image must carry %q", marker)
+		}
+
+		// The published index spans both platforms; the gate build cannot.
+		assert.Equal(t, 3, strings.Count(workflow, "platforms: linux/amd64,linux/arm64\n"),
+			"expected the push step per variant to span both platforms")
+		assert.Equal(t, 3, strings.Count(workflow, "platforms: linux/amd64\n"),
+			"the Tier A gate build stays on the gate platform")
+		// Tier B is paid once, not per variant: the toolchain it exercises is
+		// the same in all of them and the gate runs emulated.
+		assert.Equal(t, 1, strings.Count(workflow, "platforms: linux/arm64\n"),
+			"expected exactly one Tier B gate build, for ExtraGateVariant")
+		assert.Contains(t, workflow, "- name: Build linux/arm64 NG gate image EE\n")
+		assert.NotContains(t, workflow, "- name: Build linux/arm64 NG gate image FIPS\n")
+		assert.NotContains(t, workflow, "- name: Build linux/arm64 NG gate image\n")
+
+		// Pull requests use the `docker` driver, which cannot build more than
+		// one platform, so the base build has to narrow itself there.
+		assert.Contains(t, workflow,
+			"platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}")
+
+		// Emulated work must never run on a pull request: forks have no
+		// secrets, and the `docker` driver cannot load a foreign platform.
+		for _, step := range []string{
+			"Set up QEMU",
+			"Build linux/arm64 NG gate image EE",
+			"Validate linux/arm64 NG toolchain EE",
+		} {
+			idx := strings.Index(workflow, "- name: "+step+"\n")
+			require.NotEqual(t, -1, idx, "step %q not rendered", step)
+			assert.Contains(t, workflow[idx:min(idx+200, len(workflow))],
+				"if: ${{ github.event_name != 'pull_request' }}",
+				"step %q must be release-only", step)
+		}
+	})
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -117,9 +117,26 @@ type pluginCompilerNextGenConfig struct {
 	WithCxx          string
 	WithGit          string
 	GatewayTrimpath  string
-	CEArchs          string
-	EEArchs          string
-	FIPSArchs        string
+	// CEArchs, EEArchs and FIPSArchs are the architectures a plugin can be
+	// built FOR. They become the CE_ARCHS/EE_ARCHS/FIPS_ARCHS build args and
+	// are enforced at run time by data/build.sh.
+	CEArchs   string
+	EEArchs   string
+	FIPSArchs string
+	// ImagePlatforms and GatePlatform describe the compiler image ITSELF, which
+	// is a different thing: an amd64 image cross-compiles arm64 plugins today.
+	// ImagePlatforms is the platform list the image is published for.
+	// GatePlatform is the one platform that gets the full compile-and-load gate;
+	// the others are built and their toolchain exercised, but no plugin is
+	// loaded, because that needs a runner of that architecture.
+	ImagePlatforms string
+	GatePlatform   string
+	// ExtraGateVariant names the single variant whose image gets the Tier B
+	// toolchain gate on the non-gate platforms. That gate runs under emulation
+	// and costs tens of minutes, so it is not worth paying per variant when the
+	// toolchain it exercises is the same one in all of them. Empty means every
+	// variant is gated.
+	ExtraGateVariant string
 	Variants         []pluginCompilerVariant
 }
 

--- a/policy/templates/plugin-compiler-ng/.github/workflows/plugin-compiler-ng-build.yml
+++ b/policy/templates/plugin-compiler-ng/.github/workflows/plugin-compiler-ng-build.yml
@@ -70,7 +70,15 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: {{ $pc.CheckoutDepth }}
-
+{{ if $ng.ExtraImagePlatforms }}
+      # The runners are amd64. Every other image platform is built and gated
+      # under emulation, so binfmt has to be registered before buildx starts.
+      # Rendered only while {{ $ng.ImagePlatformsValue }} asks for a non-native
+      # platform -- an amd64-only image installs nothing.
+      - name: Set up QEMU
+        if: ${{`{{ github.event_name != 'pull_request' }}`}}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+{{ end }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
@@ -244,6 +252,22 @@ jobs:
             platform_digest="$digest"
           fi
           case "$platform_digest" in sha256:*) ;; *) echo "unexpected source platform digest: $platform_digest" >&2; exit 1 ;; esac
+{{- if $ng.ExtraImagePlatforms }}
+          # BASE_IMAGE is passed as the index digest, so buildx picks the right
+          # manifest per platform on its own. Check up front that every platform
+          # we are about to build is actually in there: a missing one otherwise
+          # surfaces much later as a bare "no match for platform" from a build
+          # step that has no idea which of its inputs was at fault.
+          for want in {{ $ng.ImagePlatformsValue | splitList "," | join " " }}; do
+            jq -e --arg want "$want" '
+              [.manifest.manifests[]? | select("\(.platform.os)/\(.platform.architecture)" == $want)]
+              | length == 1
+            ' <<<"$inspect" >/dev/null || {
+              echo "::error title=Base image is missing a platform::${source} does not publish ${want}; the DHI customization has to be built for it first" >&2
+              exit 1
+            }
+          done
+{{- end }}
           if [[ "$source" == *@sha256:* ]]; then
             test "${source##*@}" = "$digest"
             ref="$source"
@@ -262,6 +286,9 @@ jobs:
           digest="$(jq -er '.manifest.digest' <<<"$inspect")"
           test -n "$digest"
           case "$digest" in sha256:*) ;; *) echo "unexpected Go toolchain digest: $digest" >&2; exit 1 ;; esac
+          # amd64 on purpose, and not a copy of the base check above: golang-cross
+          # is published for amd64 only. Other platforms take the Go distribution
+          # from go.dev instead -- see the sha256 resolution further down.
           if jq -e '(.manifest.manifests? | type) == "array"' <<<"$inspect" >/dev/null; then
             platform_digest="$(jq -er '
               [.manifest.manifests[] | select(
@@ -281,13 +308,57 @@ jobs:
           echo "platform_digest=$platform_digest" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
+{{- if $ng.ImageNeedsGoTarball }}
+
+          # golang-cross is the authority for WHICH Go version the gateway uses,
+          # because the gateway release runs this same image. Read the version
+          # out of it so platforms that cannot COPY from it can still be pinned
+          # to exactly that version.
+          #
+          # This costs a full pull of golang-cross into the daemon, which is why
+          # it is not done unconditionally: an amd64 image COPYs its toolchain
+          # from that image anyway and reads the version out of it for free.
+          go_version="$(docker run --rm --platform linux/amd64 "$ref" go version | awk '{print $3}')"
+          case "$go_version" in
+            go1.*) ;;
+            *) echo "unexpected Go version from ${ref}: $go_version" >&2; exit 1 ;;
+          esac
+          echo "version=$go_version" >> "$GITHUB_OUTPUT"
+
+          # golang-cross is published for amd64 only, so every other platform
+          # takes the stock go.dev tarball at the version resolved above. Pin the
+          # checksum here, before anything is downloaded, so the image build
+          # verifies against a value settled outside it.
+          #
+          # Deliberately fatal: this only renders when a platform that needs the
+          # tarball is being built, and guessing a checksum is not an option.
+          sha_arm64="$(curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+            'https://go.dev/dl/?mode=json&include=all' | jq -er --arg v "$go_version" '
+              [.[] | select(.version == $v) | .files[]
+                 | select(.os == "linux" and .arch == "arm64" and .kind == "archive")]
+              | if length == 1 then .[0].sha256
+                else error("no unique linux-arm64 archive for \($v)")
+                end')"
+          case "$sha_arm64" in
+            ????????????????????????????????????????????????????????????????) ;;
+            *) echo "unexpected sha256 for ${go_version} linux-arm64: $sha_arm64" >&2; exit 1 ;;
+          esac
+          echo "sha256_arm64=$sha_arm64" >> "$GITHUB_OUTPUT"
+{{- end }}
+
       - name: Build workflow-local NG base
         id: build-ng-base
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: ci/images/plugin-compiler-ng
           file: ci/images/plugin-compiler-ng/Dockerfile.base
-          platforms: linux/amd64
+{{- if $ng.ExtraImagePlatforms }}
+          # Pull requests use the `docker` driver, which builds one platform
+          # only, and they never push -- so they stay on the gate platform.
+          platforms: ${{`{{ github.event_name == 'pull_request' && '`}}{{ $ng.GatePlatformValue }}{{`' || '`}}{{ $ng.ImagePlatformsValue }}{{`' }}`}}
+{{- else }}
+          platforms: {{ $ng.ImagePlatformsValue }}
+{{- end }}
           push: ${{`{{ github.event_name != 'pull_request' }}`}}
           load: ${{`{{ github.event_name == 'pull_request' }}`}}
           sbom: ${{`{{ github.event_name != 'pull_request' }}`}}
@@ -336,13 +407,18 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          # Single platform deliberately: `load: true` accepts exactly one.
+          platforms: {{ $ng.GatePlatformValue }}
           push: false
           load: true
           tags: tyk-plugin-compiler-ng-gate:{{ default "std" $variant.Name }}
           build-args: |
             BASE_IMAGE=${{`{{ env.NG_BASE_IMAGE }}`}}
             GOLANG_IMAGE=${{`{{ steps.source-go.outputs.ref }}`}}
+{{- if $ng.ImageNeedsGoTarball }}
+            GO_VERSION=${{`{{ steps.source-go.outputs.version }}`}}
+            GO_TARBALL_SHA256_ARM64=${{`{{ steps.source-go.outputs.sha256_arm64 }}`}}
+{{- end }}
             GITHUB_SHA=${{`{{ github.sha }}`}}
             GITHUB_TAG=${{`{{ github.ref_name }}`}}
             WITH_GATEWAY_SELFTEST=1{{ $ng.VariantBuildArgsBlock $variant }}
@@ -357,6 +433,47 @@ jobs:
         run: VALIDATE_ONLY=1 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate:{{ default "std" $variant.Name }} {{ $variant.NextGenEdition }} s390x
 
 {{ end }}{{ end }}
+{{- if $ng.GatesExtraPlatforms $variant }}{{ range $platform := $ng.ExtraImagePlatforms }}{{ $pslug := $platform | replace "/" "-" }}
+      # Tier B gate. The push below emits a single OCI index covering every
+      # platform, so a broken {{ $platform }} image blocks the whole push --
+      # including platforms that are perfectly fine. Build and exercise this one
+      # on its own first, where a failure is attributable and nothing has been
+      # published yet.
+      #
+      # WITH_GATEWAY_SELFTEST=0 on purpose: VALIDATE_ONLY skips the load/HTTP
+      # gate, so the gateway binary would be built under emulation and never run.
+      - name: Build {{ $platform }} NG gate image{{ $variant.StepSuffix }}
+        if: ${{`{{ github.event_name != 'pull_request' }}`}}
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
+        with:
+          context: .
+          file: ci/images/plugin-compiler-ng/Dockerfile.release
+          platforms: {{ $platform }}
+          push: false
+          load: true
+          tags: tyk-plugin-compiler-ng-gate-{{ $pslug }}:{{ default "std" $variant.Name }}
+          build-args: |
+            BASE_IMAGE=${{`{{ env.NG_BASE_IMAGE }}`}}
+            GOLANG_IMAGE=${{`{{ steps.source-go.outputs.ref }}`}}
+{{- if $ng.ImageNeedsGoTarball }}
+            GO_VERSION=${{`{{ steps.source-go.outputs.version }}`}}
+            GO_TARBALL_SHA256_ARM64=${{`{{ steps.source-go.outputs.sha256_arm64 }}`}}
+{{- end }}
+            GITHUB_SHA=${{`{{ github.sha }}`}}
+            GITHUB_TAG=${{`{{ github.ref_name }}`}}
+            WITH_GATEWAY_SELFTEST=0{{ $ng.VariantBuildArgsBlock $variant }}
+
+      # Proves the {{ $platform }} toolchain executes and emits a loadable
+      # object for its own architecture -- strictly more than the cross-build
+      # checks above, which only ever exercise the amd64 image.
+      #
+      # It stops short of plugin.Open in a {{ $platform }} gateway: that needs a
+      # runner of this architecture. See the PR for the gap and the follow-up.
+      - name: Validate {{ $platform }} NG toolchain{{ $variant.StepSuffix }}
+        if: ${{`{{ github.event_name != 'pull_request' }}`}}
+        run: VALIDATE_ONLY=1 COMPILER_PLATFORM={{ $platform }} ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate-{{ $pslug }}:{{ default "std" $variant.Name }} {{ $variant.NextGenEdition }}
+
+{{ end }}{{ end }}
       - name: Build and push NG image{{ $variant.StepSuffix }}
         if: ${{`{{ github.event_name != 'pull_request' }}`}}
         id: {{ $variant.PublishID }}
@@ -364,7 +481,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: {{ $ng.ImagePlatformsValue }}
           push: true
           sbom: true
           provenance: mode=max
@@ -373,6 +490,10 @@ jobs:
           build-args: |
             BASE_IMAGE=${{`{{ env.NG_BASE_IMAGE }}`}}
             GOLANG_IMAGE=${{`{{ steps.source-go.outputs.ref }}`}}
+{{- if $ng.ImageNeedsGoTarball }}
+            GO_VERSION=${{`{{ steps.source-go.outputs.version }}`}}
+            GO_TARBALL_SHA256_ARM64=${{`{{ steps.source-go.outputs.sha256_arm64 }}`}}
+{{- end }}
             GITHUB_SHA=${{`{{ github.sha }}`}}
             GITHUB_TAG=${{`{{ github.ref_name }}`}}
             WITH_GATEWAY_SELFTEST=0{{ $ng.VariantBuildArgsBlock $variant }}
@@ -429,6 +550,28 @@ jobs:
 
             docker buildx imagetools inspect "$exact_ref" --format '{{`{{json .Provenance}}`}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
+
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' {{ $ng.ImagePlatformsValue | splitList "," | sortAlpha | join " " }} > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly {{ $ng.ImagePlatformsValue }}" >&2
+              exit 1
+            fi
 
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"

--- a/policy/templates/plugin-compiler-ng/ci/images/plugin-compiler-ng/Dockerfile.release
+++ b/policy/templates/plugin-compiler-ng/ci/images/plugin-compiler-ng/Dockerfile.release
@@ -1,14 +1,75 @@
 # syntax=docker/dockerfile:1.7
 ARG GOLANG_IMAGE=tykio/golang-cross:{{ .Branchvals.PluginCompiler.GetGoImage .Branchvals.Buildenv }}
 ARG BASE_IMAGE
+# The exact Go version the gateway is built with, e.g. go1.26.4, as reported by
+# GOLANG_IMAGE. A compiler whose Go differs from the gateway's by so much as a
+# patch release produces plugins that fail at plugin.Open, so wherever the
+# toolchain does not come from GOLANG_IMAGE itself this has to be stated.
+#
+# Empty is legitimate and means "whatever GOLANG_IMAGE carries": on amd64 the
+# toolchain is COPYed out of that image, so the two agree by construction and
+# there is nothing to assert. Platforms that fetch Go elsewhere require it, and
+# say so where they use it.
+ARG GO_VERSION=
+ARG GO_TARBALL_SHA256_ARM64=
 
-FROM ${GOLANG_IMAGE} AS go-toolchain
+# amd64 takes the toolchain straight from golang-cross, exactly as before. The
+# gateway release runs that same image, so on this architecture the two are
+# identical by construction rather than by assertion.
+FROM --platform=linux/amd64 ${GOLANG_IMAGE} AS go-src-amd64
+
+# golang-cross is published for amd64 only, so arm64 fetches the stock go.dev
+# tarball at the version golang-cross reports. The version still originates from
+# the same image the gateway uses; only the bits come from upstream.
+#
+# Pinned to BUILDPLATFORM so the download and unpack run on the build host and
+# are never emulated -- the same approach Dockerfile.base uses for the sysroots.
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS go-src-arm64
+ARG GO_VERSION
+ARG GO_TARBALL_SHA256_ARM64
+RUN set -eux; \
+    if [ -z "$GO_VERSION" ] || [ -z "$GO_TARBALL_SHA256_ARM64" ]; then \
+        echo "ERROR: building for arm64 needs GO_VERSION and GO_TARBALL_SHA256_ARM64." >&2; \
+        echo "ERROR: golang-cross is amd64-only, so there is nothing to copy from." >&2; \
+        exit 1; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+        -o /tmp/go.tgz "https://go.dev/dl/${GO_VERSION}.linux-arm64.tar.gz"; \
+    echo "${GO_TARBALL_SHA256_ARM64}  /tmp/go.tgz" | sha256sum -c -; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    test "$(head -1 /usr/local/go/VERSION)" = "$GO_VERSION"
+
+# Selects one of the two stages above. Any other TARGETARCH fails here with
+# "failed to find stage go-src-<arch>", which is the intent: a platform with
+# no toolchain source must not silently fall through to one that has.
+FROM go-src-${TARGETARCH} AS go-toolchain
 
 FROM ${BASE_IMAGE}
+ARG GO_VERSION
 
 COPY --from=go-toolchain /usr/local/go /usr/local/go
 
-ENV GOTOOLCHAIN=local
+# When set, this is the gateway's Go version as declared from outside the image.
+# build.sh prefers it over `go version`, so validate-plugin.sh compares a built
+# plugin against the gateway's version rather than restating the image's own.
+ENV GOTOOLCHAIN=local \
+    TYK_GATEWAY_GO_VERSION=${GO_VERSION}
+
+# The toolchain that ends up here must be the gateway's, whichever stage it came
+# from. Unset means it was COPYed from GOLANG_IMAGE, where that holds by
+# construction; set means it was fetched independently and has to be proven.
+RUN set -eux; \
+    have="$(go version | awk '{print $3}')"; \
+    case "$have" in go1.*) ;; *) echo "ERROR: no usable Go toolchain: $have" >&2; exit 1 ;; esac; \
+    if [ -n "$GO_VERSION" ] && [ "$have" != "$GO_VERSION" ]; then \
+        echo "ERROR: image Go $have does not match the gateway's $GO_VERSION" >&2; \
+        echo "ERROR: plugins built here would fail to load." >&2; \
+        exit 1; \
+    fi
 
 COPY go.mod go.sum $TYK_GW_PATH/
 WORKDIR $TYK_GW_PATH

--- a/policy/templates/plugin-compiler-ng/ci/images/plugin-compiler-ng/data/build.sh
+++ b/policy/templates/plugin-compiler-ng/ci/images/plugin-compiler-ng/data/build.sh
@@ -495,7 +495,7 @@ set +x
 
 # --- Post-build validation (opt-out with VALIDATE=0) ------------------------
 if [[ "$VALIDATE" != "0" ]] && [ -x /usr/local/bin/validate-plugin.sh ]; then
-	GATEWAY_GO_VERSION="$(go version | awk '{print $3}')" \
+	GATEWAY_GO_VERSION="${TYK_GATEWAY_GO_VERSION:-$(go version | awk '{print $3}')}" \
 	EXPECT_GOARCH="$GOARCH" EXPECT_GOOS="$GOOS" \
 	MAX_GLIBC="$TYK_GLIBC_TARGET" \
 	GW_TYK_REVISION="$GITHUB_SHA" \

--- a/policy/templates/plugin-compiler-ng/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
+++ b/policy/templates/plugin-compiler-ng/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
@@ -84,8 +84,9 @@ EOF
 
 archenv=(); platform=()
 if [ -n "$GOARCH" ]; then archenv=(-e GOARCH="$GOARCH"); platform=(--platform "linux/$GOARCH"); fi
-# Optional: pin the COMPILER's own runtime platform (e.g. exercise the amd64 image under QEMU on an
-# arm64 host). Default empty = run the compiler on the host's native arch. CI never sets it.
+# Optional: pin the COMPILER's own runtime platform. Default empty = run the compiler on the host's
+# native arch. The Tier B gate sets it to exercise a non-native image under emulation, which is why
+# it pairs with VALIDATE_ONLY=1 -- the load/HTTP gate below needs a Gateway of that architecture.
 cplat=(); [ -n "${COMPILER_PLATFORM:-}" ] && cplat=(--platform "$COMPILER_PLATFORM")
 echo "== gate: building test-plugin with $COMPILER (EDITION=$EDITION GOARCH=${GOARCH:-native} compiler=${COMPILER_PLATFORM:-native}) =="
 docker run --rm -e EDITION="$EDITION" ${archenv[@]+"${archenv[@]}"} ${cplat[@]+"${cplat[@]}"} -v "$PLUGDIR:/plugin-source" "$COMPILER" plugin.so

--- a/policy/testdata/golden/tyk/master/.github/workflows/plugin-compiler-ng-build.yml
+++ b/policy/testdata/golden/tyk/master/.github/workflows/plugin-compiler-ng-build.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The runners are amd64. Every other image platform is built and gated
+      # under emulation, so binfmt has to be registered before buildx starts.
+      # Rendered only while linux/amd64,linux/arm64 asks for a non-native
+      # platform -- an amd64-only image installs nothing.
+      - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
@@ -227,6 +235,20 @@ jobs:
             platform_digest="$digest"
           fi
           case "$platform_digest" in sha256:*) ;; *) echo "unexpected source platform digest: $platform_digest" >&2; exit 1 ;; esac
+          # BASE_IMAGE is passed as the index digest, so buildx picks the right
+          # manifest per platform on its own. Check up front that every platform
+          # we are about to build is actually in there: a missing one otherwise
+          # surfaces much later as a bare "no match for platform" from a build
+          # step that has no idea which of its inputs was at fault.
+          for want in linux/amd64 linux/arm64; do
+            jq -e --arg want "$want" '
+              [.manifest.manifests[]? | select("\(.platform.os)/\(.platform.architecture)" == $want)]
+              | length == 1
+            ' <<<"$inspect" >/dev/null || {
+              echo "::error title=Base image is missing a platform::${source} does not publish ${want}; the DHI customization has to be built for it first" >&2
+              exit 1
+            }
+          done
           if [[ "$source" == *@sha256:* ]]; then
             test "${source##*@}" = "$digest"
             ref="$source"
@@ -245,6 +267,9 @@ jobs:
           digest="$(jq -er '.manifest.digest' <<<"$inspect")"
           test -n "$digest"
           case "$digest" in sha256:*) ;; *) echo "unexpected Go toolchain digest: $digest" >&2; exit 1 ;; esac
+          # amd64 on purpose, and not a copy of the base check above: golang-cross
+          # is published for amd64 only. Other platforms take the Go distribution
+          # from go.dev instead -- see the sha256 resolution further down.
           if jq -e '(.manifest.manifests? | type) == "array"' <<<"$inspect" >/dev/null; then
             platform_digest="$(jq -er '
               [.manifest.manifests[] | select(
@@ -264,13 +289,50 @@ jobs:
           echo "platform_digest=$platform_digest" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
+          # golang-cross is the authority for WHICH Go version the gateway uses,
+          # because the gateway release runs this same image. Read the version
+          # out of it so platforms that cannot COPY from it can still be pinned
+          # to exactly that version.
+          #
+          # This costs a full pull of golang-cross into the daemon, which is why
+          # it is not done unconditionally: an amd64 image COPYs its toolchain
+          # from that image anyway and reads the version out of it for free.
+          go_version="$(docker run --rm --platform linux/amd64 "$ref" go version | awk '{print $3}')"
+          case "$go_version" in
+            go1.*) ;;
+            *) echo "unexpected Go version from ${ref}: $go_version" >&2; exit 1 ;;
+          esac
+          echo "version=$go_version" >> "$GITHUB_OUTPUT"
+
+          # golang-cross is published for amd64 only, so every other platform
+          # takes the stock go.dev tarball at the version resolved above. Pin the
+          # checksum here, before anything is downloaded, so the image build
+          # verifies against a value settled outside it.
+          #
+          # Deliberately fatal: this only renders when a platform that needs the
+          # tarball is being built, and guessing a checksum is not an option.
+          sha_arm64="$(curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+            'https://go.dev/dl/?mode=json&include=all' | jq -er --arg v "$go_version" '
+              [.[] | select(.version == $v) | .files[]
+                 | select(.os == "linux" and .arch == "arm64" and .kind == "archive")]
+              | if length == 1 then .[0].sha256
+                else error("no unique linux-arm64 archive for \($v)")
+                end')"
+          case "$sha_arm64" in
+            ????????????????????????????????????????????????????????????????) ;;
+            *) echo "unexpected sha256 for ${go_version} linux-arm64: $sha_arm64" >&2; exit 1 ;;
+          esac
+          echo "sha256_arm64=$sha_arm64" >> "$GITHUB_OUTPUT"
+
       - name: Build workflow-local NG base
         id: build-ng-base
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: ci/images/plugin-compiler-ng
           file: ci/images/plugin-compiler-ng/Dockerfile.base
-          platforms: linux/amd64
+          # Pull requests use the `docker` driver, which builds one platform
+          # only, and they never push -- so they stay on the gate platform.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           sbom: ${{ github.event_name != 'pull_request' }}
@@ -319,6 +381,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -326,6 +389,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -348,7 +413,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -357,6 +422,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -415,6 +482,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -451,6 +540,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -458,6 +548,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -473,6 +565,48 @@ jobs:
         run: VALIDATE_ONLY=1 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate:ee ee arm64
 
 
+      # Tier B gate. The push below emits a single OCI index covering every
+      # platform, so a broken linux/arm64 image blocks the whole push --
+      # including platforms that are perfectly fine. Build and exercise this one
+      # on its own first, where a failure is attributable and nothing has been
+      # published yet.
+      #
+      # WITH_GATEWAY_SELFTEST=0 on purpose: VALIDATE_ONLY skips the load/HTTP
+      # gate, so the gateway binary would be built under emulation and never run.
+      - name: Build linux/arm64 NG gate image EE
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
+        with:
+          context: .
+          file: ci/images/plugin-compiler-ng/Dockerfile.release
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: tyk-plugin-compiler-ng-gate-linux-arm64:ee
+          build-args: |
+            BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
+            GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_TAG=${{ github.ref_name }}
+            WITH_GATEWAY_SELFTEST=0
+            DEFAULT_EDITION=ee
+            EE_AVAILABLE=true
+            EE_BUILD_TAG=ee
+            SELFTEST_BUILD_TAG=ee
+
+      # Proves the linux/arm64 toolchain executes and emits a loadable
+      # object for its own architecture -- strictly more than the cross-build
+      # checks above, which only ever exercise the amd64 image.
+      #
+      # It stops short of plugin.Open in a linux/arm64 gateway: that needs a
+      # runner of this architecture. See the PR for the gap and the follow-up.
+      - name: Validate linux/arm64 NG toolchain EE
+        if: ${{ github.event_name != 'pull_request' }}
+        run: VALIDATE_ONLY=1 COMPILER_PLATFORM=linux/arm64 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate-linux-arm64:ee ee
+
+
       - name: Build and push NG image EE
         if: ${{ github.event_name != 'pull_request' }}
         id: build-push-ee-ng
@@ -480,7 +614,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -489,6 +623,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -550,6 +686,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -586,6 +744,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -593,6 +752,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -617,7 +778,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -626,6 +787,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -688,6 +851,28 @@ jobs:
 
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
+
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
 
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"

--- a/policy/testdata/golden/tyk/master/ci/images/plugin-compiler-ng/Dockerfile.release
+++ b/policy/testdata/golden/tyk/master/ci/images/plugin-compiler-ng/Dockerfile.release
@@ -1,14 +1,75 @@
 # syntax=docker/dockerfile:1.7
 ARG GOLANG_IMAGE=tykio/golang-cross:1.26-bullseye
 ARG BASE_IMAGE
+# The exact Go version the gateway is built with, e.g. go1.26.4, as reported by
+# GOLANG_IMAGE. A compiler whose Go differs from the gateway's by so much as a
+# patch release produces plugins that fail at plugin.Open, so wherever the
+# toolchain does not come from GOLANG_IMAGE itself this has to be stated.
+#
+# Empty is legitimate and means "whatever GOLANG_IMAGE carries": on amd64 the
+# toolchain is COPYed out of that image, so the two agree by construction and
+# there is nothing to assert. Platforms that fetch Go elsewhere require it, and
+# say so where they use it.
+ARG GO_VERSION=
+ARG GO_TARBALL_SHA256_ARM64=
 
-FROM ${GOLANG_IMAGE} AS go-toolchain
+# amd64 takes the toolchain straight from golang-cross, exactly as before. The
+# gateway release runs that same image, so on this architecture the two are
+# identical by construction rather than by assertion.
+FROM --platform=linux/amd64 ${GOLANG_IMAGE} AS go-src-amd64
+
+# golang-cross is published for amd64 only, so arm64 fetches the stock go.dev
+# tarball at the version golang-cross reports. The version still originates from
+# the same image the gateway uses; only the bits come from upstream.
+#
+# Pinned to BUILDPLATFORM so the download and unpack run on the build host and
+# are never emulated -- the same approach Dockerfile.base uses for the sysroots.
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS go-src-arm64
+ARG GO_VERSION
+ARG GO_TARBALL_SHA256_ARM64
+RUN set -eux; \
+    if [ -z "$GO_VERSION" ] || [ -z "$GO_TARBALL_SHA256_ARM64" ]; then \
+        echo "ERROR: building for arm64 needs GO_VERSION and GO_TARBALL_SHA256_ARM64." >&2; \
+        echo "ERROR: golang-cross is amd64-only, so there is nothing to copy from." >&2; \
+        exit 1; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+        -o /tmp/go.tgz "https://go.dev/dl/${GO_VERSION}.linux-arm64.tar.gz"; \
+    echo "${GO_TARBALL_SHA256_ARM64}  /tmp/go.tgz" | sha256sum -c -; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    test "$(head -1 /usr/local/go/VERSION)" = "$GO_VERSION"
+
+# Selects one of the two stages above. Any other TARGETARCH fails here with
+# "failed to find stage go-src-<arch>", which is the intent: a platform with
+# no toolchain source must not silently fall through to one that has.
+FROM go-src-${TARGETARCH} AS go-toolchain
 
 FROM ${BASE_IMAGE}
+ARG GO_VERSION
 
 COPY --from=go-toolchain /usr/local/go /usr/local/go
 
-ENV GOTOOLCHAIN=local
+# When set, this is the gateway's Go version as declared from outside the image.
+# build.sh prefers it over `go version`, so validate-plugin.sh compares a built
+# plugin against the gateway's version rather than restating the image's own.
+ENV GOTOOLCHAIN=local \
+    TYK_GATEWAY_GO_VERSION=${GO_VERSION}
+
+# The toolchain that ends up here must be the gateway's, whichever stage it came
+# from. Unset means it was COPYed from GOLANG_IMAGE, where that holds by
+# construction; set means it was fetched independently and has to be proven.
+RUN set -eux; \
+    have="$(go version | awk '{print $3}')"; \
+    case "$have" in go1.*) ;; *) echo "ERROR: no usable Go toolchain: $have" >&2; exit 1 ;; esac; \
+    if [ -n "$GO_VERSION" ] && [ "$have" != "$GO_VERSION" ]; then \
+        echo "ERROR: image Go $have does not match the gateway's $GO_VERSION" >&2; \
+        echo "ERROR: plugins built here would fail to load." >&2; \
+        exit 1; \
+    fi
 
 COPY go.mod go.sum $TYK_GW_PATH/
 WORKDIR $TYK_GW_PATH

--- a/policy/testdata/golden/tyk/master/ci/images/plugin-compiler-ng/data/build.sh
+++ b/policy/testdata/golden/tyk/master/ci/images/plugin-compiler-ng/data/build.sh
@@ -495,7 +495,7 @@ set +x
 
 # --- Post-build validation (opt-out with VALIDATE=0) ------------------------
 if [[ "$VALIDATE" != "0" ]] && [ -x /usr/local/bin/validate-plugin.sh ]; then
-	GATEWAY_GO_VERSION="$(go version | awk '{print $3}')" \
+	GATEWAY_GO_VERSION="${TYK_GATEWAY_GO_VERSION:-$(go version | awk '{print $3}')}" \
 	EXPECT_GOARCH="$GOARCH" EXPECT_GOOS="$GOOS" \
 	MAX_GLIBC="$TYK_GLIBC_TARGET" \
 	GW_TYK_REVISION="$GITHUB_SHA" \

--- a/policy/testdata/golden/tyk/master/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
+++ b/policy/testdata/golden/tyk/master/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
@@ -84,8 +84,9 @@ EOF
 
 archenv=(); platform=()
 if [ -n "$GOARCH" ]; then archenv=(-e GOARCH="$GOARCH"); platform=(--platform "linux/$GOARCH"); fi
-# Optional: pin the COMPILER's own runtime platform (e.g. exercise the amd64 image under QEMU on an
-# arm64 host). Default empty = run the compiler on the host's native arch. CI never sets it.
+# Optional: pin the COMPILER's own runtime platform. Default empty = run the compiler on the host's
+# native arch. The Tier B gate sets it to exercise a non-native image under emulation, which is why
+# it pairs with VALIDATE_ONLY=1 -- the load/HTTP gate below needs a Gateway of that architecture.
 cplat=(); [ -n "${COMPILER_PLATFORM:-}" ] && cplat=(--platform "$COMPILER_PLATFORM")
 echo "== gate: building test-plugin with $COMPILER (EDITION=$EDITION GOARCH=${GOARCH:-native} compiler=${COMPILER_PLATFORM:-native}) =="
 docker run --rm -e EDITION="$EDITION" ${archenv[@]+"${archenv[@]}"} ${cplat[@]+"${cplat[@]}"} -v "$PLUGDIR:/plugin-source" "$COMPILER" plugin.so

--- a/policy/testdata/golden/tyk/release-5.13.2/.github/workflows/plugin-compiler-ng-build.yml
+++ b/policy/testdata/golden/tyk/release-5.13.2/.github/workflows/plugin-compiler-ng-build.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The runners are amd64. Every other image platform is built and gated
+      # under emulation, so binfmt has to be registered before buildx starts.
+      # Rendered only while linux/amd64,linux/arm64 asks for a non-native
+      # platform -- an amd64-only image installs nothing.
+      - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
@@ -227,6 +235,20 @@ jobs:
             platform_digest="$digest"
           fi
           case "$platform_digest" in sha256:*) ;; *) echo "unexpected source platform digest: $platform_digest" >&2; exit 1 ;; esac
+          # BASE_IMAGE is passed as the index digest, so buildx picks the right
+          # manifest per platform on its own. Check up front that every platform
+          # we are about to build is actually in there: a missing one otherwise
+          # surfaces much later as a bare "no match for platform" from a build
+          # step that has no idea which of its inputs was at fault.
+          for want in linux/amd64 linux/arm64; do
+            jq -e --arg want "$want" '
+              [.manifest.manifests[]? | select("\(.platform.os)/\(.platform.architecture)" == $want)]
+              | length == 1
+            ' <<<"$inspect" >/dev/null || {
+              echo "::error title=Base image is missing a platform::${source} does not publish ${want}; the DHI customization has to be built for it first" >&2
+              exit 1
+            }
+          done
           if [[ "$source" == *@sha256:* ]]; then
             test "${source##*@}" = "$digest"
             ref="$source"
@@ -245,6 +267,9 @@ jobs:
           digest="$(jq -er '.manifest.digest' <<<"$inspect")"
           test -n "$digest"
           case "$digest" in sha256:*) ;; *) echo "unexpected Go toolchain digest: $digest" >&2; exit 1 ;; esac
+          # amd64 on purpose, and not a copy of the base check above: golang-cross
+          # is published for amd64 only. Other platforms take the Go distribution
+          # from go.dev instead -- see the sha256 resolution further down.
           if jq -e '(.manifest.manifests? | type) == "array"' <<<"$inspect" >/dev/null; then
             platform_digest="$(jq -er '
               [.manifest.manifests[] | select(
@@ -264,13 +289,50 @@ jobs:
           echo "platform_digest=$platform_digest" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
+          # golang-cross is the authority for WHICH Go version the gateway uses,
+          # because the gateway release runs this same image. Read the version
+          # out of it so platforms that cannot COPY from it can still be pinned
+          # to exactly that version.
+          #
+          # This costs a full pull of golang-cross into the daemon, which is why
+          # it is not done unconditionally: an amd64 image COPYs its toolchain
+          # from that image anyway and reads the version out of it for free.
+          go_version="$(docker run --rm --platform linux/amd64 "$ref" go version | awk '{print $3}')"
+          case "$go_version" in
+            go1.*) ;;
+            *) echo "unexpected Go version from ${ref}: $go_version" >&2; exit 1 ;;
+          esac
+          echo "version=$go_version" >> "$GITHUB_OUTPUT"
+
+          # golang-cross is published for amd64 only, so every other platform
+          # takes the stock go.dev tarball at the version resolved above. Pin the
+          # checksum here, before anything is downloaded, so the image build
+          # verifies against a value settled outside it.
+          #
+          # Deliberately fatal: this only renders when a platform that needs the
+          # tarball is being built, and guessing a checksum is not an option.
+          sha_arm64="$(curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+            'https://go.dev/dl/?mode=json&include=all' | jq -er --arg v "$go_version" '
+              [.[] | select(.version == $v) | .files[]
+                 | select(.os == "linux" and .arch == "arm64" and .kind == "archive")]
+              | if length == 1 then .[0].sha256
+                else error("no unique linux-arm64 archive for \($v)")
+                end')"
+          case "$sha_arm64" in
+            ????????????????????????????????????????????????????????????????) ;;
+            *) echo "unexpected sha256 for ${go_version} linux-arm64: $sha_arm64" >&2; exit 1 ;;
+          esac
+          echo "sha256_arm64=$sha_arm64" >> "$GITHUB_OUTPUT"
+
       - name: Build workflow-local NG base
         id: build-ng-base
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: ci/images/plugin-compiler-ng
           file: ci/images/plugin-compiler-ng/Dockerfile.base
-          platforms: linux/amd64
+          # Pull requests use the `docker` driver, which builds one platform
+          # only, and they never push -- so they stay on the gate platform.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           sbom: ${{ github.event_name != 'pull_request' }}
@@ -319,6 +381,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -326,6 +389,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -348,7 +413,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -357,6 +422,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -415,6 +482,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -451,6 +540,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -458,6 +548,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -473,6 +565,48 @@ jobs:
         run: VALIDATE_ONLY=1 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate:ee ee arm64
 
 
+      # Tier B gate. The push below emits a single OCI index covering every
+      # platform, so a broken linux/arm64 image blocks the whole push --
+      # including platforms that are perfectly fine. Build and exercise this one
+      # on its own first, where a failure is attributable and nothing has been
+      # published yet.
+      #
+      # WITH_GATEWAY_SELFTEST=0 on purpose: VALIDATE_ONLY skips the load/HTTP
+      # gate, so the gateway binary would be built under emulation and never run.
+      - name: Build linux/arm64 NG gate image EE
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
+        with:
+          context: .
+          file: ci/images/plugin-compiler-ng/Dockerfile.release
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: tyk-plugin-compiler-ng-gate-linux-arm64:ee
+          build-args: |
+            BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
+            GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_TAG=${{ github.ref_name }}
+            WITH_GATEWAY_SELFTEST=0
+            DEFAULT_EDITION=ee
+            EE_AVAILABLE=true
+            EE_BUILD_TAG=ee
+            SELFTEST_BUILD_TAG=ee
+
+      # Proves the linux/arm64 toolchain executes and emits a loadable
+      # object for its own architecture -- strictly more than the cross-build
+      # checks above, which only ever exercise the amd64 image.
+      #
+      # It stops short of plugin.Open in a linux/arm64 gateway: that needs a
+      # runner of this architecture. See the PR for the gap and the follow-up.
+      - name: Validate linux/arm64 NG toolchain EE
+        if: ${{ github.event_name != 'pull_request' }}
+        run: VALIDATE_ONLY=1 COMPILER_PLATFORM=linux/arm64 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate-linux-arm64:ee ee
+
+
       - name: Build and push NG image EE
         if: ${{ github.event_name != 'pull_request' }}
         id: build-push-ee-ng
@@ -480,7 +614,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -489,6 +623,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -550,6 +686,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -586,6 +744,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -593,6 +752,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -617,7 +778,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -626,6 +787,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -688,6 +851,28 @@ jobs:
 
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
+
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
 
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"

--- a/policy/testdata/golden/tyk/release-5.13.2/ci/images/plugin-compiler-ng/Dockerfile.release
+++ b/policy/testdata/golden/tyk/release-5.13.2/ci/images/plugin-compiler-ng/Dockerfile.release
@@ -1,14 +1,75 @@
 # syntax=docker/dockerfile:1.7
 ARG GOLANG_IMAGE=tykio/golang-cross:1.26-bullseye
 ARG BASE_IMAGE
+# The exact Go version the gateway is built with, e.g. go1.26.4, as reported by
+# GOLANG_IMAGE. A compiler whose Go differs from the gateway's by so much as a
+# patch release produces plugins that fail at plugin.Open, so wherever the
+# toolchain does not come from GOLANG_IMAGE itself this has to be stated.
+#
+# Empty is legitimate and means "whatever GOLANG_IMAGE carries": on amd64 the
+# toolchain is COPYed out of that image, so the two agree by construction and
+# there is nothing to assert. Platforms that fetch Go elsewhere require it, and
+# say so where they use it.
+ARG GO_VERSION=
+ARG GO_TARBALL_SHA256_ARM64=
 
-FROM ${GOLANG_IMAGE} AS go-toolchain
+# amd64 takes the toolchain straight from golang-cross, exactly as before. The
+# gateway release runs that same image, so on this architecture the two are
+# identical by construction rather than by assertion.
+FROM --platform=linux/amd64 ${GOLANG_IMAGE} AS go-src-amd64
+
+# golang-cross is published for amd64 only, so arm64 fetches the stock go.dev
+# tarball at the version golang-cross reports. The version still originates from
+# the same image the gateway uses; only the bits come from upstream.
+#
+# Pinned to BUILDPLATFORM so the download and unpack run on the build host and
+# are never emulated -- the same approach Dockerfile.base uses for the sysroots.
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS go-src-arm64
+ARG GO_VERSION
+ARG GO_TARBALL_SHA256_ARM64
+RUN set -eux; \
+    if [ -z "$GO_VERSION" ] || [ -z "$GO_TARBALL_SHA256_ARM64" ]; then \
+        echo "ERROR: building for arm64 needs GO_VERSION and GO_TARBALL_SHA256_ARM64." >&2; \
+        echo "ERROR: golang-cross is amd64-only, so there is nothing to copy from." >&2; \
+        exit 1; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+        -o /tmp/go.tgz "https://go.dev/dl/${GO_VERSION}.linux-arm64.tar.gz"; \
+    echo "${GO_TARBALL_SHA256_ARM64}  /tmp/go.tgz" | sha256sum -c -; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    test "$(head -1 /usr/local/go/VERSION)" = "$GO_VERSION"
+
+# Selects one of the two stages above. Any other TARGETARCH fails here with
+# "failed to find stage go-src-<arch>", which is the intent: a platform with
+# no toolchain source must not silently fall through to one that has.
+FROM go-src-${TARGETARCH} AS go-toolchain
 
 FROM ${BASE_IMAGE}
+ARG GO_VERSION
 
 COPY --from=go-toolchain /usr/local/go /usr/local/go
 
-ENV GOTOOLCHAIN=local
+# When set, this is the gateway's Go version as declared from outside the image.
+# build.sh prefers it over `go version`, so validate-plugin.sh compares a built
+# plugin against the gateway's version rather than restating the image's own.
+ENV GOTOOLCHAIN=local \
+    TYK_GATEWAY_GO_VERSION=${GO_VERSION}
+
+# The toolchain that ends up here must be the gateway's, whichever stage it came
+# from. Unset means it was COPYed from GOLANG_IMAGE, where that holds by
+# construction; set means it was fetched independently and has to be proven.
+RUN set -eux; \
+    have="$(go version | awk '{print $3}')"; \
+    case "$have" in go1.*) ;; *) echo "ERROR: no usable Go toolchain: $have" >&2; exit 1 ;; esac; \
+    if [ -n "$GO_VERSION" ] && [ "$have" != "$GO_VERSION" ]; then \
+        echo "ERROR: image Go $have does not match the gateway's $GO_VERSION" >&2; \
+        echo "ERROR: plugins built here would fail to load." >&2; \
+        exit 1; \
+    fi
 
 COPY go.mod go.sum $TYK_GW_PATH/
 WORKDIR $TYK_GW_PATH

--- a/policy/testdata/golden/tyk/release-5.13.2/ci/images/plugin-compiler-ng/data/build.sh
+++ b/policy/testdata/golden/tyk/release-5.13.2/ci/images/plugin-compiler-ng/data/build.sh
@@ -495,7 +495,7 @@ set +x
 
 # --- Post-build validation (opt-out with VALIDATE=0) ------------------------
 if [[ "$VALIDATE" != "0" ]] && [ -x /usr/local/bin/validate-plugin.sh ]; then
-	GATEWAY_GO_VERSION="$(go version | awk '{print $3}')" \
+	GATEWAY_GO_VERSION="${TYK_GATEWAY_GO_VERSION:-$(go version | awk '{print $3}')}" \
 	EXPECT_GOARCH="$GOARCH" EXPECT_GOOS="$GOOS" \
 	MAX_GLIBC="$TYK_GLIBC_TARGET" \
 	GW_TYK_REVISION="$GITHUB_SHA" \

--- a/policy/testdata/golden/tyk/release-5.13.2/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
+++ b/policy/testdata/golden/tyk/release-5.13.2/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
@@ -84,8 +84,9 @@ EOF
 
 archenv=(); platform=()
 if [ -n "$GOARCH" ]; then archenv=(-e GOARCH="$GOARCH"); platform=(--platform "linux/$GOARCH"); fi
-# Optional: pin the COMPILER's own runtime platform (e.g. exercise the amd64 image under QEMU on an
-# arm64 host). Default empty = run the compiler on the host's native arch. CI never sets it.
+# Optional: pin the COMPILER's own runtime platform. Default empty = run the compiler on the host's
+# native arch. The Tier B gate sets it to exercise a non-native image under emulation, which is why
+# it pairs with VALIDATE_ONLY=1 -- the load/HTTP gate below needs a Gateway of that architecture.
 cplat=(); [ -n "${COMPILER_PLATFORM:-}" ] && cplat=(--platform "$COMPILER_PLATFORM")
 echo "== gate: building test-plugin with $COMPILER (EDITION=$EDITION GOARCH=${GOARCH:-native} compiler=${COMPILER_PLATFORM:-native}) =="
 docker run --rm -e EDITION="$EDITION" ${archenv[@]+"${archenv[@]}"} ${cplat[@]+"${cplat[@]}"} -v "$PLUGDIR:/plugin-source" "$COMPILER" plugin.so

--- a/policy/testdata/golden/tyk/release-5.13/.github/workflows/plugin-compiler-ng-build.yml
+++ b/policy/testdata/golden/tyk/release-5.13/.github/workflows/plugin-compiler-ng-build.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The runners are amd64. Every other image platform is built and gated
+      # under emulation, so binfmt has to be registered before buildx starts.
+      # Rendered only while linux/amd64,linux/arm64 asks for a non-native
+      # platform -- an amd64-only image installs nothing.
+      - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
@@ -227,6 +235,20 @@ jobs:
             platform_digest="$digest"
           fi
           case "$platform_digest" in sha256:*) ;; *) echo "unexpected source platform digest: $platform_digest" >&2; exit 1 ;; esac
+          # BASE_IMAGE is passed as the index digest, so buildx picks the right
+          # manifest per platform on its own. Check up front that every platform
+          # we are about to build is actually in there: a missing one otherwise
+          # surfaces much later as a bare "no match for platform" from a build
+          # step that has no idea which of its inputs was at fault.
+          for want in linux/amd64 linux/arm64; do
+            jq -e --arg want "$want" '
+              [.manifest.manifests[]? | select("\(.platform.os)/\(.platform.architecture)" == $want)]
+              | length == 1
+            ' <<<"$inspect" >/dev/null || {
+              echo "::error title=Base image is missing a platform::${source} does not publish ${want}; the DHI customization has to be built for it first" >&2
+              exit 1
+            }
+          done
           if [[ "$source" == *@sha256:* ]]; then
             test "${source##*@}" = "$digest"
             ref="$source"
@@ -245,6 +267,9 @@ jobs:
           digest="$(jq -er '.manifest.digest' <<<"$inspect")"
           test -n "$digest"
           case "$digest" in sha256:*) ;; *) echo "unexpected Go toolchain digest: $digest" >&2; exit 1 ;; esac
+          # amd64 on purpose, and not a copy of the base check above: golang-cross
+          # is published for amd64 only. Other platforms take the Go distribution
+          # from go.dev instead -- see the sha256 resolution further down.
           if jq -e '(.manifest.manifests? | type) == "array"' <<<"$inspect" >/dev/null; then
             platform_digest="$(jq -er '
               [.manifest.manifests[] | select(
@@ -264,13 +289,50 @@ jobs:
           echo "platform_digest=$platform_digest" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
+          # golang-cross is the authority for WHICH Go version the gateway uses,
+          # because the gateway release runs this same image. Read the version
+          # out of it so platforms that cannot COPY from it can still be pinned
+          # to exactly that version.
+          #
+          # This costs a full pull of golang-cross into the daemon, which is why
+          # it is not done unconditionally: an amd64 image COPYs its toolchain
+          # from that image anyway and reads the version out of it for free.
+          go_version="$(docker run --rm --platform linux/amd64 "$ref" go version | awk '{print $3}')"
+          case "$go_version" in
+            go1.*) ;;
+            *) echo "unexpected Go version from ${ref}: $go_version" >&2; exit 1 ;;
+          esac
+          echo "version=$go_version" >> "$GITHUB_OUTPUT"
+
+          # golang-cross is published for amd64 only, so every other platform
+          # takes the stock go.dev tarball at the version resolved above. Pin the
+          # checksum here, before anything is downloaded, so the image build
+          # verifies against a value settled outside it.
+          #
+          # Deliberately fatal: this only renders when a platform that needs the
+          # tarball is being built, and guessing a checksum is not an option.
+          sha_arm64="$(curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+            'https://go.dev/dl/?mode=json&include=all' | jq -er --arg v "$go_version" '
+              [.[] | select(.version == $v) | .files[]
+                 | select(.os == "linux" and .arch == "arm64" and .kind == "archive")]
+              | if length == 1 then .[0].sha256
+                else error("no unique linux-arm64 archive for \($v)")
+                end')"
+          case "$sha_arm64" in
+            ????????????????????????????????????????????????????????????????) ;;
+            *) echo "unexpected sha256 for ${go_version} linux-arm64: $sha_arm64" >&2; exit 1 ;;
+          esac
+          echo "sha256_arm64=$sha_arm64" >> "$GITHUB_OUTPUT"
+
       - name: Build workflow-local NG base
         id: build-ng-base
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: ci/images/plugin-compiler-ng
           file: ci/images/plugin-compiler-ng/Dockerfile.base
-          platforms: linux/amd64
+          # Pull requests use the `docker` driver, which builds one platform
+          # only, and they never push -- so they stay on the gate platform.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           sbom: ${{ github.event_name != 'pull_request' }}
@@ -319,6 +381,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -326,6 +389,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -348,7 +413,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -357,6 +422,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -415,6 +482,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -451,6 +540,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -458,6 +548,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -473,6 +565,48 @@ jobs:
         run: VALIDATE_ONLY=1 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate:ee ee arm64
 
 
+      # Tier B gate. The push below emits a single OCI index covering every
+      # platform, so a broken linux/arm64 image blocks the whole push --
+      # including platforms that are perfectly fine. Build and exercise this one
+      # on its own first, where a failure is attributable and nothing has been
+      # published yet.
+      #
+      # WITH_GATEWAY_SELFTEST=0 on purpose: VALIDATE_ONLY skips the load/HTTP
+      # gate, so the gateway binary would be built under emulation and never run.
+      - name: Build linux/arm64 NG gate image EE
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
+        with:
+          context: .
+          file: ci/images/plugin-compiler-ng/Dockerfile.release
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: tyk-plugin-compiler-ng-gate-linux-arm64:ee
+          build-args: |
+            BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
+            GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_TAG=${{ github.ref_name }}
+            WITH_GATEWAY_SELFTEST=0
+            DEFAULT_EDITION=ee
+            EE_AVAILABLE=true
+            EE_BUILD_TAG=ee
+            SELFTEST_BUILD_TAG=ee
+
+      # Proves the linux/arm64 toolchain executes and emits a loadable
+      # object for its own architecture -- strictly more than the cross-build
+      # checks above, which only ever exercise the amd64 image.
+      #
+      # It stops short of plugin.Open in a linux/arm64 gateway: that needs a
+      # runner of this architecture. See the PR for the gap and the follow-up.
+      - name: Validate linux/arm64 NG toolchain EE
+        if: ${{ github.event_name != 'pull_request' }}
+        run: VALIDATE_ONLY=1 COMPILER_PLATFORM=linux/arm64 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate-linux-arm64:ee ee
+
+
       - name: Build and push NG image EE
         if: ${{ github.event_name != 'pull_request' }}
         id: build-push-ee-ng
@@ -480,7 +614,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -489,6 +623,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -550,6 +686,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -586,6 +744,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -593,6 +752,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -617,7 +778,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -626,6 +787,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -688,6 +851,28 @@ jobs:
 
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
+
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
 
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"

--- a/policy/testdata/golden/tyk/release-5.13/ci/images/plugin-compiler-ng/Dockerfile.release
+++ b/policy/testdata/golden/tyk/release-5.13/ci/images/plugin-compiler-ng/Dockerfile.release
@@ -1,14 +1,75 @@
 # syntax=docker/dockerfile:1.7
 ARG GOLANG_IMAGE=tykio/golang-cross:1.26-bullseye
 ARG BASE_IMAGE
+# The exact Go version the gateway is built with, e.g. go1.26.4, as reported by
+# GOLANG_IMAGE. A compiler whose Go differs from the gateway's by so much as a
+# patch release produces plugins that fail at plugin.Open, so wherever the
+# toolchain does not come from GOLANG_IMAGE itself this has to be stated.
+#
+# Empty is legitimate and means "whatever GOLANG_IMAGE carries": on amd64 the
+# toolchain is COPYed out of that image, so the two agree by construction and
+# there is nothing to assert. Platforms that fetch Go elsewhere require it, and
+# say so where they use it.
+ARG GO_VERSION=
+ARG GO_TARBALL_SHA256_ARM64=
 
-FROM ${GOLANG_IMAGE} AS go-toolchain
+# amd64 takes the toolchain straight from golang-cross, exactly as before. The
+# gateway release runs that same image, so on this architecture the two are
+# identical by construction rather than by assertion.
+FROM --platform=linux/amd64 ${GOLANG_IMAGE} AS go-src-amd64
+
+# golang-cross is published for amd64 only, so arm64 fetches the stock go.dev
+# tarball at the version golang-cross reports. The version still originates from
+# the same image the gateway uses; only the bits come from upstream.
+#
+# Pinned to BUILDPLATFORM so the download and unpack run on the build host and
+# are never emulated -- the same approach Dockerfile.base uses for the sysroots.
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS go-src-arm64
+ARG GO_VERSION
+ARG GO_TARBALL_SHA256_ARM64
+RUN set -eux; \
+    if [ -z "$GO_VERSION" ] || [ -z "$GO_TARBALL_SHA256_ARM64" ]; then \
+        echo "ERROR: building for arm64 needs GO_VERSION and GO_TARBALL_SHA256_ARM64." >&2; \
+        echo "ERROR: golang-cross is amd64-only, so there is nothing to copy from." >&2; \
+        exit 1; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+        -o /tmp/go.tgz "https://go.dev/dl/${GO_VERSION}.linux-arm64.tar.gz"; \
+    echo "${GO_TARBALL_SHA256_ARM64}  /tmp/go.tgz" | sha256sum -c -; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    test "$(head -1 /usr/local/go/VERSION)" = "$GO_VERSION"
+
+# Selects one of the two stages above. Any other TARGETARCH fails here with
+# "failed to find stage go-src-<arch>", which is the intent: a platform with
+# no toolchain source must not silently fall through to one that has.
+FROM go-src-${TARGETARCH} AS go-toolchain
 
 FROM ${BASE_IMAGE}
+ARG GO_VERSION
 
 COPY --from=go-toolchain /usr/local/go /usr/local/go
 
-ENV GOTOOLCHAIN=local
+# When set, this is the gateway's Go version as declared from outside the image.
+# build.sh prefers it over `go version`, so validate-plugin.sh compares a built
+# plugin against the gateway's version rather than restating the image's own.
+ENV GOTOOLCHAIN=local \
+    TYK_GATEWAY_GO_VERSION=${GO_VERSION}
+
+# The toolchain that ends up here must be the gateway's, whichever stage it came
+# from. Unset means it was COPYed from GOLANG_IMAGE, where that holds by
+# construction; set means it was fetched independently and has to be proven.
+RUN set -eux; \
+    have="$(go version | awk '{print $3}')"; \
+    case "$have" in go1.*) ;; *) echo "ERROR: no usable Go toolchain: $have" >&2; exit 1 ;; esac; \
+    if [ -n "$GO_VERSION" ] && [ "$have" != "$GO_VERSION" ]; then \
+        echo "ERROR: image Go $have does not match the gateway's $GO_VERSION" >&2; \
+        echo "ERROR: plugins built here would fail to load." >&2; \
+        exit 1; \
+    fi
 
 COPY go.mod go.sum $TYK_GW_PATH/
 WORKDIR $TYK_GW_PATH

--- a/policy/testdata/golden/tyk/release-5.13/ci/images/plugin-compiler-ng/data/build.sh
+++ b/policy/testdata/golden/tyk/release-5.13/ci/images/plugin-compiler-ng/data/build.sh
@@ -495,7 +495,7 @@ set +x
 
 # --- Post-build validation (opt-out with VALIDATE=0) ------------------------
 if [[ "$VALIDATE" != "0" ]] && [ -x /usr/local/bin/validate-plugin.sh ]; then
-	GATEWAY_GO_VERSION="$(go version | awk '{print $3}')" \
+	GATEWAY_GO_VERSION="${TYK_GATEWAY_GO_VERSION:-$(go version | awk '{print $3}')}" \
 	EXPECT_GOARCH="$GOARCH" EXPECT_GOOS="$GOOS" \
 	MAX_GLIBC="$TYK_GLIBC_TARGET" \
 	GW_TYK_REVISION="$GITHUB_SHA" \

--- a/policy/testdata/golden/tyk/release-5.13/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
+++ b/policy/testdata/golden/tyk/release-5.13/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
@@ -84,8 +84,9 @@ EOF
 
 archenv=(); platform=()
 if [ -n "$GOARCH" ]; then archenv=(-e GOARCH="$GOARCH"); platform=(--platform "linux/$GOARCH"); fi
-# Optional: pin the COMPILER's own runtime platform (e.g. exercise the amd64 image under QEMU on an
-# arm64 host). Default empty = run the compiler on the host's native arch. CI never sets it.
+# Optional: pin the COMPILER's own runtime platform. Default empty = run the compiler on the host's
+# native arch. The Tier B gate sets it to exercise a non-native image under emulation, which is why
+# it pairs with VALIDATE_ONLY=1 -- the load/HTTP gate below needs a Gateway of that architecture.
 cplat=(); [ -n "${COMPILER_PLATFORM:-}" ] && cplat=(--platform "$COMPILER_PLATFORM")
 echo "== gate: building test-plugin with $COMPILER (EDITION=$EDITION GOARCH=${GOARCH:-native} compiler=${COMPILER_PLATFORM:-native}) =="
 docker run --rm -e EDITION="$EDITION" ${archenv[@]+"${archenv[@]}"} ${cplat[@]+"${cplat[@]}"} -v "$PLUGDIR:/plugin-source" "$COMPILER" plugin.so

--- a/policy/testdata/golden/tyk/release-5.15.0/.github/workflows/plugin-compiler-ng-build.yml
+++ b/policy/testdata/golden/tyk/release-5.15.0/.github/workflows/plugin-compiler-ng-build.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The runners are amd64. Every other image platform is built and gated
+      # under emulation, so binfmt has to be registered before buildx starts.
+      # Rendered only while linux/amd64,linux/arm64 asks for a non-native
+      # platform -- an amd64-only image installs nothing.
+      - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
@@ -227,6 +235,20 @@ jobs:
             platform_digest="$digest"
           fi
           case "$platform_digest" in sha256:*) ;; *) echo "unexpected source platform digest: $platform_digest" >&2; exit 1 ;; esac
+          # BASE_IMAGE is passed as the index digest, so buildx picks the right
+          # manifest per platform on its own. Check up front that every platform
+          # we are about to build is actually in there: a missing one otherwise
+          # surfaces much later as a bare "no match for platform" from a build
+          # step that has no idea which of its inputs was at fault.
+          for want in linux/amd64 linux/arm64; do
+            jq -e --arg want "$want" '
+              [.manifest.manifests[]? | select("\(.platform.os)/\(.platform.architecture)" == $want)]
+              | length == 1
+            ' <<<"$inspect" >/dev/null || {
+              echo "::error title=Base image is missing a platform::${source} does not publish ${want}; the DHI customization has to be built for it first" >&2
+              exit 1
+            }
+          done
           if [[ "$source" == *@sha256:* ]]; then
             test "${source##*@}" = "$digest"
             ref="$source"
@@ -245,6 +267,9 @@ jobs:
           digest="$(jq -er '.manifest.digest' <<<"$inspect")"
           test -n "$digest"
           case "$digest" in sha256:*) ;; *) echo "unexpected Go toolchain digest: $digest" >&2; exit 1 ;; esac
+          # amd64 on purpose, and not a copy of the base check above: golang-cross
+          # is published for amd64 only. Other platforms take the Go distribution
+          # from go.dev instead -- see the sha256 resolution further down.
           if jq -e '(.manifest.manifests? | type) == "array"' <<<"$inspect" >/dev/null; then
             platform_digest="$(jq -er '
               [.manifest.manifests[] | select(
@@ -264,13 +289,50 @@ jobs:
           echo "platform_digest=$platform_digest" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
+          # golang-cross is the authority for WHICH Go version the gateway uses,
+          # because the gateway release runs this same image. Read the version
+          # out of it so platforms that cannot COPY from it can still be pinned
+          # to exactly that version.
+          #
+          # This costs a full pull of golang-cross into the daemon, which is why
+          # it is not done unconditionally: an amd64 image COPYs its toolchain
+          # from that image anyway and reads the version out of it for free.
+          go_version="$(docker run --rm --platform linux/amd64 "$ref" go version | awk '{print $3}')"
+          case "$go_version" in
+            go1.*) ;;
+            *) echo "unexpected Go version from ${ref}: $go_version" >&2; exit 1 ;;
+          esac
+          echo "version=$go_version" >> "$GITHUB_OUTPUT"
+
+          # golang-cross is published for amd64 only, so every other platform
+          # takes the stock go.dev tarball at the version resolved above. Pin the
+          # checksum here, before anything is downloaded, so the image build
+          # verifies against a value settled outside it.
+          #
+          # Deliberately fatal: this only renders when a platform that needs the
+          # tarball is being built, and guessing a checksum is not an option.
+          sha_arm64="$(curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+            'https://go.dev/dl/?mode=json&include=all' | jq -er --arg v "$go_version" '
+              [.[] | select(.version == $v) | .files[]
+                 | select(.os == "linux" and .arch == "arm64" and .kind == "archive")]
+              | if length == 1 then .[0].sha256
+                else error("no unique linux-arm64 archive for \($v)")
+                end')"
+          case "$sha_arm64" in
+            ????????????????????????????????????????????????????????????????) ;;
+            *) echo "unexpected sha256 for ${go_version} linux-arm64: $sha_arm64" >&2; exit 1 ;;
+          esac
+          echo "sha256_arm64=$sha_arm64" >> "$GITHUB_OUTPUT"
+
       - name: Build workflow-local NG base
         id: build-ng-base
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: ci/images/plugin-compiler-ng
           file: ci/images/plugin-compiler-ng/Dockerfile.base
-          platforms: linux/amd64
+          # Pull requests use the `docker` driver, which builds one platform
+          # only, and they never push -- so they stay on the gate platform.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           sbom: ${{ github.event_name != 'pull_request' }}
@@ -319,6 +381,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -326,6 +389,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -348,7 +413,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -357,6 +422,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -415,6 +482,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -451,6 +540,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -458,6 +548,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -473,6 +565,48 @@ jobs:
         run: VALIDATE_ONLY=1 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate:ee ee arm64
 
 
+      # Tier B gate. The push below emits a single OCI index covering every
+      # platform, so a broken linux/arm64 image blocks the whole push --
+      # including platforms that are perfectly fine. Build and exercise this one
+      # on its own first, where a failure is attributable and nothing has been
+      # published yet.
+      #
+      # WITH_GATEWAY_SELFTEST=0 on purpose: VALIDATE_ONLY skips the load/HTTP
+      # gate, so the gateway binary would be built under emulation and never run.
+      - name: Build linux/arm64 NG gate image EE
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
+        with:
+          context: .
+          file: ci/images/plugin-compiler-ng/Dockerfile.release
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: tyk-plugin-compiler-ng-gate-linux-arm64:ee
+          build-args: |
+            BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
+            GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_TAG=${{ github.ref_name }}
+            WITH_GATEWAY_SELFTEST=0
+            DEFAULT_EDITION=ee
+            EE_AVAILABLE=true
+            EE_BUILD_TAG=ee
+            SELFTEST_BUILD_TAG=ee
+
+      # Proves the linux/arm64 toolchain executes and emits a loadable
+      # object for its own architecture -- strictly more than the cross-build
+      # checks above, which only ever exercise the amd64 image.
+      #
+      # It stops short of plugin.Open in a linux/arm64 gateway: that needs a
+      # runner of this architecture. See the PR for the gap and the follow-up.
+      - name: Validate linux/arm64 NG toolchain EE
+        if: ${{ github.event_name != 'pull_request' }}
+        run: VALIDATE_ONLY=1 COMPILER_PLATFORM=linux/arm64 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate-linux-arm64:ee ee
+
+
       - name: Build and push NG image EE
         if: ${{ github.event_name != 'pull_request' }}
         id: build-push-ee-ng
@@ -480,7 +614,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -489,6 +623,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -550,6 +686,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -586,6 +744,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -593,6 +752,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -617,7 +778,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -626,6 +787,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -688,6 +851,28 @@ jobs:
 
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
+
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
 
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"

--- a/policy/testdata/golden/tyk/release-5.15.0/ci/images/plugin-compiler-ng/Dockerfile.release
+++ b/policy/testdata/golden/tyk/release-5.15.0/ci/images/plugin-compiler-ng/Dockerfile.release
@@ -1,14 +1,75 @@
 # syntax=docker/dockerfile:1.7
 ARG GOLANG_IMAGE=tykio/golang-cross:1.26-bullseye
 ARG BASE_IMAGE
+# The exact Go version the gateway is built with, e.g. go1.26.4, as reported by
+# GOLANG_IMAGE. A compiler whose Go differs from the gateway's by so much as a
+# patch release produces plugins that fail at plugin.Open, so wherever the
+# toolchain does not come from GOLANG_IMAGE itself this has to be stated.
+#
+# Empty is legitimate and means "whatever GOLANG_IMAGE carries": on amd64 the
+# toolchain is COPYed out of that image, so the two agree by construction and
+# there is nothing to assert. Platforms that fetch Go elsewhere require it, and
+# say so where they use it.
+ARG GO_VERSION=
+ARG GO_TARBALL_SHA256_ARM64=
 
-FROM ${GOLANG_IMAGE} AS go-toolchain
+# amd64 takes the toolchain straight from golang-cross, exactly as before. The
+# gateway release runs that same image, so on this architecture the two are
+# identical by construction rather than by assertion.
+FROM --platform=linux/amd64 ${GOLANG_IMAGE} AS go-src-amd64
+
+# golang-cross is published for amd64 only, so arm64 fetches the stock go.dev
+# tarball at the version golang-cross reports. The version still originates from
+# the same image the gateway uses; only the bits come from upstream.
+#
+# Pinned to BUILDPLATFORM so the download and unpack run on the build host and
+# are never emulated -- the same approach Dockerfile.base uses for the sysroots.
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS go-src-arm64
+ARG GO_VERSION
+ARG GO_TARBALL_SHA256_ARM64
+RUN set -eux; \
+    if [ -z "$GO_VERSION" ] || [ -z "$GO_TARBALL_SHA256_ARM64" ]; then \
+        echo "ERROR: building for arm64 needs GO_VERSION and GO_TARBALL_SHA256_ARM64." >&2; \
+        echo "ERROR: golang-cross is amd64-only, so there is nothing to copy from." >&2; \
+        exit 1; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+        -o /tmp/go.tgz "https://go.dev/dl/${GO_VERSION}.linux-arm64.tar.gz"; \
+    echo "${GO_TARBALL_SHA256_ARM64}  /tmp/go.tgz" | sha256sum -c -; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    test "$(head -1 /usr/local/go/VERSION)" = "$GO_VERSION"
+
+# Selects one of the two stages above. Any other TARGETARCH fails here with
+# "failed to find stage go-src-<arch>", which is the intent: a platform with
+# no toolchain source must not silently fall through to one that has.
+FROM go-src-${TARGETARCH} AS go-toolchain
 
 FROM ${BASE_IMAGE}
+ARG GO_VERSION
 
 COPY --from=go-toolchain /usr/local/go /usr/local/go
 
-ENV GOTOOLCHAIN=local
+# When set, this is the gateway's Go version as declared from outside the image.
+# build.sh prefers it over `go version`, so validate-plugin.sh compares a built
+# plugin against the gateway's version rather than restating the image's own.
+ENV GOTOOLCHAIN=local \
+    TYK_GATEWAY_GO_VERSION=${GO_VERSION}
+
+# The toolchain that ends up here must be the gateway's, whichever stage it came
+# from. Unset means it was COPYed from GOLANG_IMAGE, where that holds by
+# construction; set means it was fetched independently and has to be proven.
+RUN set -eux; \
+    have="$(go version | awk '{print $3}')"; \
+    case "$have" in go1.*) ;; *) echo "ERROR: no usable Go toolchain: $have" >&2; exit 1 ;; esac; \
+    if [ -n "$GO_VERSION" ] && [ "$have" != "$GO_VERSION" ]; then \
+        echo "ERROR: image Go $have does not match the gateway's $GO_VERSION" >&2; \
+        echo "ERROR: plugins built here would fail to load." >&2; \
+        exit 1; \
+    fi
 
 COPY go.mod go.sum $TYK_GW_PATH/
 WORKDIR $TYK_GW_PATH

--- a/policy/testdata/golden/tyk/release-5.15.0/ci/images/plugin-compiler-ng/data/build.sh
+++ b/policy/testdata/golden/tyk/release-5.15.0/ci/images/plugin-compiler-ng/data/build.sh
@@ -495,7 +495,7 @@ set +x
 
 # --- Post-build validation (opt-out with VALIDATE=0) ------------------------
 if [[ "$VALIDATE" != "0" ]] && [ -x /usr/local/bin/validate-plugin.sh ]; then
-	GATEWAY_GO_VERSION="$(go version | awk '{print $3}')" \
+	GATEWAY_GO_VERSION="${TYK_GATEWAY_GO_VERSION:-$(go version | awk '{print $3}')}" \
 	EXPECT_GOARCH="$GOARCH" EXPECT_GOOS="$GOOS" \
 	MAX_GLIBC="$TYK_GLIBC_TARGET" \
 	GW_TYK_REVISION="$GITHUB_SHA" \

--- a/policy/testdata/golden/tyk/release-5.15.0/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
+++ b/policy/testdata/golden/tyk/release-5.15.0/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
@@ -84,8 +84,9 @@ EOF
 
 archenv=(); platform=()
 if [ -n "$GOARCH" ]; then archenv=(-e GOARCH="$GOARCH"); platform=(--platform "linux/$GOARCH"); fi
-# Optional: pin the COMPILER's own runtime platform (e.g. exercise the amd64 image under QEMU on an
-# arm64 host). Default empty = run the compiler on the host's native arch. CI never sets it.
+# Optional: pin the COMPILER's own runtime platform. Default empty = run the compiler on the host's
+# native arch. The Tier B gate sets it to exercise a non-native image under emulation, which is why
+# it pairs with VALIDATE_ONLY=1 -- the load/HTTP gate below needs a Gateway of that architecture.
 cplat=(); [ -n "${COMPILER_PLATFORM:-}" ] && cplat=(--platform "$COMPILER_PLATFORM")
 echo "== gate: building test-plugin with $COMPILER (EDITION=$EDITION GOARCH=${GOARCH:-native} compiler=${COMPILER_PLATFORM:-native}) =="
 docker run --rm -e EDITION="$EDITION" ${archenv[@]+"${archenv[@]}"} ${cplat[@]+"${cplat[@]}"} -v "$PLUGDIR:/plugin-source" "$COMPILER" plugin.so

--- a/policy/testdata/golden/tyk/release-5.15/.github/workflows/plugin-compiler-ng-build.yml
+++ b/policy/testdata/golden/tyk/release-5.15/.github/workflows/plugin-compiler-ng-build.yml
@@ -57,6 +57,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # The runners are amd64. Every other image platform is built and gated
+      # under emulation, so binfmt has to be registered before buildx starts.
+      # Rendered only while linux/amd64,linux/arm64 asks for a non-native
+      # platform -- an amd64-only image installs nothing.
+      - name: Set up QEMU
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
         with:
@@ -227,6 +235,20 @@ jobs:
             platform_digest="$digest"
           fi
           case "$platform_digest" in sha256:*) ;; *) echo "unexpected source platform digest: $platform_digest" >&2; exit 1 ;; esac
+          # BASE_IMAGE is passed as the index digest, so buildx picks the right
+          # manifest per platform on its own. Check up front that every platform
+          # we are about to build is actually in there: a missing one otherwise
+          # surfaces much later as a bare "no match for platform" from a build
+          # step that has no idea which of its inputs was at fault.
+          for want in linux/amd64 linux/arm64; do
+            jq -e --arg want "$want" '
+              [.manifest.manifests[]? | select("\(.platform.os)/\(.platform.architecture)" == $want)]
+              | length == 1
+            ' <<<"$inspect" >/dev/null || {
+              echo "::error title=Base image is missing a platform::${source} does not publish ${want}; the DHI customization has to be built for it first" >&2
+              exit 1
+            }
+          done
           if [[ "$source" == *@sha256:* ]]; then
             test "${source##*@}" = "$digest"
             ref="$source"
@@ -245,6 +267,9 @@ jobs:
           digest="$(jq -er '.manifest.digest' <<<"$inspect")"
           test -n "$digest"
           case "$digest" in sha256:*) ;; *) echo "unexpected Go toolchain digest: $digest" >&2; exit 1 ;; esac
+          # amd64 on purpose, and not a copy of the base check above: golang-cross
+          # is published for amd64 only. Other platforms take the Go distribution
+          # from go.dev instead -- see the sha256 resolution further down.
           if jq -e '(.manifest.manifests? | type) == "array"' <<<"$inspect" >/dev/null; then
             platform_digest="$(jq -er '
               [.manifest.manifests[] | select(
@@ -264,13 +289,50 @@ jobs:
           echo "platform_digest=$platform_digest" >> "$GITHUB_OUTPUT"
           echo "ref=$ref" >> "$GITHUB_OUTPUT"
 
+          # golang-cross is the authority for WHICH Go version the gateway uses,
+          # because the gateway release runs this same image. Read the version
+          # out of it so platforms that cannot COPY from it can still be pinned
+          # to exactly that version.
+          #
+          # This costs a full pull of golang-cross into the daemon, which is why
+          # it is not done unconditionally: an amd64 image COPYs its toolchain
+          # from that image anyway and reads the version out of it for free.
+          go_version="$(docker run --rm --platform linux/amd64 "$ref" go version | awk '{print $3}')"
+          case "$go_version" in
+            go1.*) ;;
+            *) echo "unexpected Go version from ${ref}: $go_version" >&2; exit 1 ;;
+          esac
+          echo "version=$go_version" >> "$GITHUB_OUTPUT"
+
+          # golang-cross is published for amd64 only, so every other platform
+          # takes the stock go.dev tarball at the version resolved above. Pin the
+          # checksum here, before anything is downloaded, so the image build
+          # verifies against a value settled outside it.
+          #
+          # Deliberately fatal: this only renders when a platform that needs the
+          # tarball is being built, and guessing a checksum is not an option.
+          sha_arm64="$(curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+            'https://go.dev/dl/?mode=json&include=all' | jq -er --arg v "$go_version" '
+              [.[] | select(.version == $v) | .files[]
+                 | select(.os == "linux" and .arch == "arm64" and .kind == "archive")]
+              | if length == 1 then .[0].sha256
+                else error("no unique linux-arm64 archive for \($v)")
+                end')"
+          case "$sha_arm64" in
+            ????????????????????????????????????????????????????????????????) ;;
+            *) echo "unexpected sha256 for ${go_version} linux-arm64: $sha_arm64" >&2; exit 1 ;;
+          esac
+          echo "sha256_arm64=$sha_arm64" >> "$GITHUB_OUTPUT"
+
       - name: Build workflow-local NG base
         id: build-ng-base
         uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
         with:
           context: ci/images/plugin-compiler-ng
           file: ci/images/plugin-compiler-ng/Dockerfile.base
-          platforms: linux/amd64
+          # Pull requests use the `docker` driver, which builds one platform
+          # only, and they never push -- so they stay on the gate platform.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           sbom: ${{ github.event_name != 'pull_request' }}
@@ -319,6 +381,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -326,6 +389,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -348,7 +413,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -357,6 +422,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -415,6 +482,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -451,6 +540,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -458,6 +548,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -473,6 +565,48 @@ jobs:
         run: VALIDATE_ONLY=1 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate:ee ee arm64
 
 
+      # Tier B gate. The push below emits a single OCI index covering every
+      # platform, so a broken linux/arm64 image blocks the whole push --
+      # including platforms that are perfectly fine. Build and exercise this one
+      # on its own first, where a failure is attributable and nothing has been
+      # published yet.
+      #
+      # WITH_GATEWAY_SELFTEST=0 on purpose: VALIDATE_ONLY skips the load/HTTP
+      # gate, so the gateway binary would be built under emulation and never run.
+      - name: Build linux/arm64 NG gate image EE
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9  # v4
+        with:
+          context: .
+          file: ci/images/plugin-compiler-ng/Dockerfile.release
+          platforms: linux/arm64
+          push: false
+          load: true
+          tags: tyk-plugin-compiler-ng-gate-linux-arm64:ee
+          build-args: |
+            BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
+            GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_TAG=${{ github.ref_name }}
+            WITH_GATEWAY_SELFTEST=0
+            DEFAULT_EDITION=ee
+            EE_AVAILABLE=true
+            EE_BUILD_TAG=ee
+            SELFTEST_BUILD_TAG=ee
+
+      # Proves the linux/arm64 toolchain executes and emits a loadable
+      # object for its own architecture -- strictly more than the cross-build
+      # checks above, which only ever exercise the amd64 image.
+      #
+      # It stops short of plugin.Open in a linux/arm64 gateway: that needs a
+      # runner of this architecture. See the PR for the gap and the follow-up.
+      - name: Validate linux/arm64 NG toolchain EE
+        if: ${{ github.event_name != 'pull_request' }}
+        run: VALIDATE_ONLY=1 COMPILER_PLATFORM=linux/arm64 ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh tyk-plugin-compiler-ng-gate-linux-arm64:ee ee
+
+
       - name: Build and push NG image EE
         if: ${{ github.event_name != 'pull_request' }}
         id: build-push-ee-ng
@@ -480,7 +614,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -489,6 +623,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -550,6 +686,28 @@ jobs:
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
 
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
+
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"
 
@@ -586,6 +744,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
+          # Single platform deliberately: `load: true` accepts exactly one.
           platforms: linux/amd64
           push: false
           load: true
@@ -593,6 +752,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=1
@@ -617,7 +778,7 @@ jobs:
         with:
           context: .
           file: ci/images/plugin-compiler-ng/Dockerfile.release
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sbom: true
           provenance: mode=max
@@ -626,6 +787,8 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ env.NG_BASE_IMAGE }}
             GOLANG_IMAGE=${{ steps.source-go.outputs.ref }}
+            GO_VERSION=${{ steps.source-go.outputs.version }}
+            GO_TARBALL_SHA256_ARM64=${{ steps.source-go.outputs.sha256_arm64 }}
             GITHUB_SHA=${{ github.sha }}
             GITHUB_TAG=${{ github.ref_name }}
             WITH_GATEWAY_SELFTEST=0
@@ -688,6 +851,28 @@ jobs:
 
             docker buildx imagetools inspect "$exact_ref" --format '{{json .Provenance}}' > "$provenance_file"
             jq -e '[.. | objects | select(has("SLSA"))] | length > 0' "$provenance_file" >/dev/null
+
+            # The index must offer exactly the platforms that were asked for --
+            # no more, no fewer. buildx reports success for a partially built
+            # index, and an attestation manifest carries `unknown/unknown`, so
+            # counting manifests or trusting the exit code would both pass while
+            # a platform silently went missing. `.manifests` being absent
+            # entirely means the push produced a bare manifest instead of an
+            # index, which is the same failure in its most extreme form, so name
+            # it rather than letting jq fall over on a missing key.
+            platforms_file="$evidence_dir/${safe_repository}.platforms.txt"
+            docker buildx imagetools inspect "$exact_ref" --raw |
+              jq -er 'if has("manifests") then
+                        .manifests[]
+                        | select(.platform.os != "unknown")   # attestations carry unknown/unknown
+                        | "\(.platform.os)/\(.platform.architecture)"
+                      else error("published ref is not an image index") end' |
+              sort -u > "$platforms_file"
+            printf '%s\n' linux/amd64 linux/arm64 > "$evidence_dir/platforms.expected.txt"
+            if ! diff -u "$evidence_dir/platforms.expected.txt" "$platforms_file"; then
+              echo "::error title=Published platforms do not match::${exact_ref} does not publish exactly linux/amd64,linux/arm64" >&2
+              exit 1
+            fi
 
             printf 'verified %s\n' "$exact_ref" | tee -a "$evidence_dir/verified-refs.txt" "$GITHUB_STEP_SUMMARY"
           done < "$repositories"

--- a/policy/testdata/golden/tyk/release-5.15/ci/images/plugin-compiler-ng/Dockerfile.release
+++ b/policy/testdata/golden/tyk/release-5.15/ci/images/plugin-compiler-ng/Dockerfile.release
@@ -1,14 +1,75 @@
 # syntax=docker/dockerfile:1.7
 ARG GOLANG_IMAGE=tykio/golang-cross:1.26-bullseye
 ARG BASE_IMAGE
+# The exact Go version the gateway is built with, e.g. go1.26.4, as reported by
+# GOLANG_IMAGE. A compiler whose Go differs from the gateway's by so much as a
+# patch release produces plugins that fail at plugin.Open, so wherever the
+# toolchain does not come from GOLANG_IMAGE itself this has to be stated.
+#
+# Empty is legitimate and means "whatever GOLANG_IMAGE carries": on amd64 the
+# toolchain is COPYed out of that image, so the two agree by construction and
+# there is nothing to assert. Platforms that fetch Go elsewhere require it, and
+# say so where they use it.
+ARG GO_VERSION=
+ARG GO_TARBALL_SHA256_ARM64=
 
-FROM ${GOLANG_IMAGE} AS go-toolchain
+# amd64 takes the toolchain straight from golang-cross, exactly as before. The
+# gateway release runs that same image, so on this architecture the two are
+# identical by construction rather than by assertion.
+FROM --platform=linux/amd64 ${GOLANG_IMAGE} AS go-src-amd64
+
+# golang-cross is published for amd64 only, so arm64 fetches the stock go.dev
+# tarball at the version golang-cross reports. The version still originates from
+# the same image the gateway uses; only the bits come from upstream.
+#
+# Pinned to BUILDPLATFORM so the download and unpack run on the build host and
+# are never emulated -- the same approach Dockerfile.base uses for the sysroots.
+FROM --platform=$BUILDPLATFORM debian:bookworm-slim AS go-src-arm64
+ARG GO_VERSION
+ARG GO_TARBALL_SHA256_ARM64
+RUN set -eux; \
+    if [ -z "$GO_VERSION" ] || [ -z "$GO_TARBALL_SHA256_ARM64" ]; then \
+        echo "ERROR: building for arm64 needs GO_VERSION and GO_TARBALL_SHA256_ARM64." >&2; \
+        echo "ERROR: golang-cross is amd64-only, so there is nothing to copy from." >&2; \
+        exit 1; \
+    fi; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    rm -rf /var/lib/apt/lists/*; \
+    curl -fsSL --retry 3 --proto '=https' --tlsv1.2 \
+        -o /tmp/go.tgz "https://go.dev/dl/${GO_VERSION}.linux-arm64.tar.gz"; \
+    echo "${GO_TARBALL_SHA256_ARM64}  /tmp/go.tgz" | sha256sum -c -; \
+    tar -C /usr/local -xzf /tmp/go.tgz; \
+    rm /tmp/go.tgz; \
+    test "$(head -1 /usr/local/go/VERSION)" = "$GO_VERSION"
+
+# Selects one of the two stages above. Any other TARGETARCH fails here with
+# "failed to find stage go-src-<arch>", which is the intent: a platform with
+# no toolchain source must not silently fall through to one that has.
+FROM go-src-${TARGETARCH} AS go-toolchain
 
 FROM ${BASE_IMAGE}
+ARG GO_VERSION
 
 COPY --from=go-toolchain /usr/local/go /usr/local/go
 
-ENV GOTOOLCHAIN=local
+# When set, this is the gateway's Go version as declared from outside the image.
+# build.sh prefers it over `go version`, so validate-plugin.sh compares a built
+# plugin against the gateway's version rather than restating the image's own.
+ENV GOTOOLCHAIN=local \
+    TYK_GATEWAY_GO_VERSION=${GO_VERSION}
+
+# The toolchain that ends up here must be the gateway's, whichever stage it came
+# from. Unset means it was COPYed from GOLANG_IMAGE, where that holds by
+# construction; set means it was fetched independently and has to be proven.
+RUN set -eux; \
+    have="$(go version | awk '{print $3}')"; \
+    case "$have" in go1.*) ;; *) echo "ERROR: no usable Go toolchain: $have" >&2; exit 1 ;; esac; \
+    if [ -n "$GO_VERSION" ] && [ "$have" != "$GO_VERSION" ]; then \
+        echo "ERROR: image Go $have does not match the gateway's $GO_VERSION" >&2; \
+        echo "ERROR: plugins built here would fail to load." >&2; \
+        exit 1; \
+    fi
 
 COPY go.mod go.sum $TYK_GW_PATH/
 WORKDIR $TYK_GW_PATH

--- a/policy/testdata/golden/tyk/release-5.15/ci/images/plugin-compiler-ng/data/build.sh
+++ b/policy/testdata/golden/tyk/release-5.15/ci/images/plugin-compiler-ng/data/build.sh
@@ -495,7 +495,7 @@ set +x
 
 # --- Post-build validation (opt-out with VALIDATE=0) ------------------------
 if [[ "$VALIDATE" != "0" ]] && [ -x /usr/local/bin/validate-plugin.sh ]; then
-	GATEWAY_GO_VERSION="$(go version | awk '{print $3}')" \
+	GATEWAY_GO_VERSION="${TYK_GATEWAY_GO_VERSION:-$(go version | awk '{print $3}')}" \
 	EXPECT_GOARCH="$GOARCH" EXPECT_GOOS="$GOOS" \
 	MAX_GLIBC="$TYK_GLIBC_TARGET" \
 	GW_TYK_REVISION="$GITHUB_SHA" \

--- a/policy/testdata/golden/tyk/release-5.15/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
+++ b/policy/testdata/golden/tyk/release-5.15/ci/images/plugin-compiler-ng/scripts/loadtest-gate.sh
@@ -84,8 +84,9 @@ EOF
 
 archenv=(); platform=()
 if [ -n "$GOARCH" ]; then archenv=(-e GOARCH="$GOARCH"); platform=(--platform "linux/$GOARCH"); fi
-# Optional: pin the COMPILER's own runtime platform (e.g. exercise the amd64 image under QEMU on an
-# arm64 host). Default empty = run the compiler on the host's native arch. CI never sets it.
+# Optional: pin the COMPILER's own runtime platform. Default empty = run the compiler on the host's
+# native arch. The Tier B gate sets it to exercise a non-native image under emulation, which is why
+# it pairs with VALIDATE_ONLY=1 -- the load/HTTP gate below needs a Gateway of that architecture.
 cplat=(); [ -n "${COMPILER_PLATFORM:-}" ] && cplat=(--platform "$COMPILER_PLATFORM")
 echo "== gate: building test-plugin with $COMPILER (EDITION=$EDITION GOARCH=${GOARCH:-native} compiler=${COMPILER_PLATFORM:-native}) =="
 docker run --rm -e EDITION="$EDITION" ${archenv[@]+"${archenv[@]}"} ${cplat[@]+"${cplat[@]}"} -v "$PLUGDIR:/plugin-source" "$COMPILER" plugin.so

--- a/policy/tfuncs.go
+++ b/policy/tfuncs.go
@@ -324,3 +324,64 @@ func (ng pluginCompilerNextGenConfig) CustomizationOrgValue() string {
 	}
 	return ""
 }
+
+// ImagePlatformsValue is the platform list the compiler image is published for.
+// This is the image's own architecture, not the architectures a plugin can be
+// built for -- see CEArchsValue and friends for those.
+func (ng pluginCompilerNextGenConfig) ImagePlatformsValue() string {
+	if ng.ImagePlatforms != "" {
+		return ng.ImagePlatforms
+	}
+	return "linux/amd64"
+}
+
+// GatePlatformValue is the platform that runs the full compile-and-load gate.
+// It must appear in ImagePlatformsValue; a gate build uses `load: true`, which
+// accepts a single platform only.
+func (ng pluginCompilerNextGenConfig) GatePlatformValue() string {
+	if ng.GatePlatform != "" {
+		return ng.GatePlatform
+	}
+	return "linux/amd64"
+}
+
+// ImageNeedsGoTarball reports whether any requested image platform has to fetch
+// the Go toolchain from go.dev instead of copying it out of golang-cross, which
+// is published for amd64 only. When it is false the workflow makes no go.dev
+// call at all, so an amd64-only build gains no new network dependency.
+func (ng pluginCompilerNextGenConfig) ImageNeedsGoTarball() bool {
+	for _, p := range strings.Split(ng.ImagePlatformsValue(), ",") {
+		if p = strings.TrimSpace(p); p != "" && p != "linux/amd64" {
+			return true
+		}
+	}
+	return false
+}
+
+// GatesExtraPlatforms reports whether this variant gets the Tier B toolchain
+// gate. With ExtraGateVariant set, exactly one variant does; the others publish
+// their extra platforms on the strength of that one plus the full gate they
+// each get on GatePlatformValue.
+func (ng pluginCompilerNextGenConfig) GatesExtraPlatforms(v pluginCompilerVariant) bool {
+	if ng.ExtraGateVariant == "" {
+		return true
+	}
+	name := v.Name
+	if name == "" {
+		name = "std"
+	}
+	return name == ng.ExtraGateVariant
+}
+
+// ExtraImagePlatforms is ImagePlatformsValue minus GatePlatformValue: the
+// platforms that are published but do not get the full gate.
+func (ng pluginCompilerNextGenConfig) ExtraImagePlatforms() []string {
+	gate := ng.GatePlatformValue()
+	var extra []string
+	for _, p := range strings.Split(ng.ImagePlatformsValue(), ",") {
+		if p = strings.TrimSpace(p); p != "" && p != gate {
+			extra = append(extra, p)
+		}
+	}
+	return extra
+}


### PR DESCRIPTION
## What

Publishes the NG plugin compiler image for `linux/arm64` alongside `linux/amd64`, so it runs natively on Apple silicon and Graviton instead of under emulation.

Both compilers already **cross-compile** arm64 plugins — that is not what changes here. What was missing is a compiler image that **runs** on an arm64 host.

## Why it is not a one-line platform change

`tykio/golang-cross` is amd64-only, and `Dockerfile.release` copies `/usr/local/go` out of it. That Go has to *execute* in the image. Go plugins must match the gateway's Go down to the patch release or they fail at `plugin.Open`, so arm64 needs an arm64 Go at exactly the version golang-cross carries.

- **amd64 is untouched** — still `COPY --from=golang-cross`. Identical *by construction* beats identical *by assertion*, and preserving it costs one extra `FROM`.
- **arm64 demotes golang-cross to a version oracle** and fetches the stock go.dev tarball at that version, sha256-pinned before anything downloads, unpacked on `$BUILDPLATFORM` so it is never emulated.

Making golang-cross multi-arch was rejected: it carries a macOS SDK, goreleaser, qemu-user-static and three cross toolchains NG does not use; building it under QEMU is hours per tag, and republishing affects every consumer including the gateway release.

## A validation hole this closes

`data/build.sh` derived `GATEWAY_GO_VERSION` from the *image's own* toolchain, so it proved `plugin == image` and never `image == gateway`. A drifted arm64 image would have validated cleanly and emitted plugins that fail to load. It now prefers `TYK_GATEWAY_GO_VERSION`, declared from outside the image.

## The feature flag

`imageplatforms` describes the **image's own** platforms — a different thing from `cearchs`/`eearchs`/`fipsarchs`, which are what a *plugin* can be built for. Rollback is a one-line config revert plus a re-render.

It is set at group level rather than per branch on purpose: **a branch-level `plugincompiler:` block replaces the group-level one wholesale instead of merging.** Setting only `nextgen.imageplatforms` under `master` silently reset `NG_BASE_SOURCE` to `dhi.io/busybox:1-debian-fips-dev` and took the DHI customization id with it. Worth knowing before anyone tries a per-branch NG override.

## Gates

- **Tier A** (unchanged, every variant): full compile, `plugin.Open`, live HTTP on `gateplatform`.
- **Tier B** (new, EE only): builds the arm64 image on its own and exercises its toolchain *before* anything is pushed. The push emits a single OCI index, so an arm64 failure would otherwise block the amd64 push with no attributable cause. Paid once rather than per variant — the toolchain is identical across variants and the gate runs emulated.

Two assertions that did not exist before: the base index must carry every requested platform *before* building (otherwise a missing one surfaces later as a bare "no match for platform"), and the published index must offer exactly the requested set — `buildx` reports success for a partial index, and attestation manifests carry `unknown/unknown`, so counting manifests would pass while a platform went missing.

## Verification

`go test ./...` and `actionlint` on all five rendered NG workflows are clean. The amd64 render is additive only — no `platforms:` line changes.

Verified end-to-end on **native arm64 hardware**, both editions — compiler builds a plugin, `tyk plugin load` opens it in an arm64 gateway, and the plugin executes in a live request:

```
[ok] architecture: AArch64
[ok] go toolchain: go1.26.7 (matches gateway)
[ok] edition: 'ee' build tag present
[ok] FIPS: GOFIPS140=v1.0.0-c2097c7c (embedded build setting)
[ok] GLIBC ceiling: 2.17 <= 2.17
[file=/gate-plugin.so, symbol=AddFooBarHeader] loaded ok, got 0xffff052b8b60
GATE PASS: AddFooBarHeader changed the proxied request (Foo: Bar) for EDITION=ee-fips
```

Also confirmed the arm64 DHI base carries the full cross toolchain (`gcc`, `g++`, and all three of `x86_64-`/`aarch64-`/`s390x-linux-gnu-`, at `14.2.0-19+dhi3` — DHI-provisioned, not apt-installed).

Negative tests: a wrong tarball checksum fails the build, and missing `GO_VERSION`/`GO_TARBALL_SHA256_ARM64` fails with an explicit message rather than a confusing downstream error.

## Known gap

**CI never exercises arm64 `plugin.Open`.** Closing it properly needs an arm64 runner, which the org does not have, so `gateplatform` stays `linux/amd64` and Tier B stops at building and validating the object. The load-and-run path above was proven manually on arm64 hardware; it is not re-checked per release.

Caveat on that evidence: it was Apple silicon, not a Graviton-class Linux host. Same architecture and same container images, so the ABI result carries, but it does not rule out Docker Desktop's VM differing from a Linux runner in ways unrelated to arch.

## Cost

Tier B runs under QEMU on release jobs only — PRs are untouched. Expect roughly 15–25 minutes added. That range is an estimate from native timings (1:46–2:22) scaled for emulation; it has not been measured on a runner yet, and the first release run will tell us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)