### PR TITLE
TT-17995: run nightly-marked API tests on every trigger

### DIFF
--- a/config/tui/prod-variations.yml
+++ b/config/tui/prod-variations.yml
@@ -2,7 +2,7 @@ envfiles: # this set up will be used in all executions below.
   - cache: "redis7"
     config: "sha256"
     db: "mongo7"
-    apimarkers: "not local and not dind and not nightly"
+    apimarkers: "not local and not dind"
     pump: "$ECR/tyk-pump:master"
     sink: "$ECR/tyk-sink:master"
     gwdash: master # this is used only for on-schedule triggers, for others it is ignored
@@ -18,7 +18,7 @@ level: # testsuites
         - cache: "valkey8_1"
           config: "murmur128"
           db: "postgres15"
-          apimarkers: "not local and not dind and not sql and not nightly"
+          apimarkers: "not local and not dind and not sql"
           gwdash: master
           pump: "$ECR/tyk-pump:master"
           sink: "$ECR/tyk-sink:master"
@@ -49,7 +49,7 @@ level: # testsuites
         - cache: "valkey9_1"
           config: "murmur128"
           db: "postgres15"
-          apimarkers: "not local and not dind and not sql and not nightly"
+          apimarkers: "not local and not dind and not sql"
           gwdash: master
           pump: "$ECR/tyk-pump:master"
           sink: "$ECR/tyk-sink:master"
@@ -108,12 +108,12 @@ level: # testsuites
                   - cache: "redis8_2"
                     config: "sha256"
                     db: "mongo7"
-                    apimarkers: "not local and not dind and not nightly"
+                    apimarkers: "not local and not dind"
                     gwdash: release-5.13
                   - cache: "valkey8_1"
                     config: "murmur128"
                     db: "postgres16"
-                    apimarkers: "not local and not dind and not sql and not nightly"
+                    apimarkers: "not local and not dind and not sql"
                     gwdash: release-5.8
           push:
             level: # repos

--- a/config/tui/test-variations.yml
+++ b/config/tui/test-variations.yml
@@ -2,7 +2,7 @@ envfiles: # this set up will be used in all executions below.
   - cache: "redis7"
     config: "sha256"
     db: "mongo7"
-    apimarkers: "not local and not dind and not nightly"
+    apimarkers: "not local and not dind"
     pump: "$ECR/tyk-pump:master"
     sink: "$ECR/tyk-sink:master"
     gwdash: master # this is used only for on-schedule triggers, for others it is ignored
@@ -18,7 +18,7 @@ level: # testsuites
         - cache: "valkey8_1"
           config: "murmur128"
           db: "postgres15"
-          apimarkers: "not local and not dind and not nightly"
+          apimarkers: "not local and not dind"
           gwdash: master
           pump: "$ECR/tyk-pump:master"
           sink: "$ECR/tyk-sink:master"
@@ -49,7 +49,7 @@ level: # testsuites
         - cache: "valkey9_1"
           config: "murmur128"
           db: "postgres15"
-          apimarkers: "not local and not dind and not sql and not nightly"
+          apimarkers: "not local and not dind and not sql"
           gwdash: master
           pump: "tykio/tyk-pump-docker-pub:v1.14.1"
           sink: "tykio/tyk-mdcb-docker:v2.11.0"
@@ -107,12 +107,12 @@ level: # testsuites
                   - cache: "redis8_2"
                     config: "sha256"
                     db: "mongo7"
-                    apimarkers: "not local and not dind and not nightly"
+                    apimarkers: "not local and not dind"
                     gwdash: release-5.13
                   - cache: "valkey8_1"
                     config: "murmur128"
                     db: "postgres16"
-                    apimarkers: "not local and not dind and not sql and not nightly"
+                    apimarkers: "not local and not dind and not sql"
                     gwdash: release-5.8
           push:
             level: # repos


### PR DESCRIPTION
## What

Drops `and not nightly` from every `apimarkers` string in the TUI variation config — 5 occurrences in `config/tui/prod-variations.yml`, 5 in `config/tui/test-variations.yml`.

API test execution is fast enough now that there's no reason to hold the `nightly`-marked tests back to scheduled runs. This makes PR, push and `workflow_dispatch` runs pick up the ~58 `@pytest.mark.nightly` tests in `tyk-analytics/tests/api` as well.

## Side effect: fixes the scheduled runs too

Envfiles **accumulate** down the variation tree rather than override (`policy/variations.go:201` appends the parent's `EnvFiles` onto each child). So the `schedule` leaves were inheriting the branch-level and global-level envfiles — two of which still carried `not nightly`.

Concretely, `prod-variation/tyk-analytics/master/schedule/api` emitted 8 envfile combos, not the 6 declared, and 2 of the 8 skipped exactly the tests the nightly run exists to cover. That's gone now.

## Verification

- `go build ./...` — clean
- `go test ./policy/...` — pass
- `gromit policy generate-tui` regenerated cleanly; no `nightly` remains anywhere in the generated `.gho` output

## Rollout

`pages.yml` triggers on pushes to `master` touching `config/tui/**`, so merging republishes the static TUI site and `test-controller` picks it up on the next run. No downstream `release.yml` regeneration needed. Reverting is a one-commit rollback.

## Follow-ups (not in this PR)

- The `nightly` marker in `tyk-analytics/tests/api/pytest_ci.ini` and its 58 decorators are now inert. They should be removed, otherwise people keep adding `@pytest.mark.nightly` expecting a PR-skip that no longer happens.
- `github-actions/.github/actions/tests/test-controller/db-variations.yml` still carries `not nightly` in 2 places, but nothing references that file — the action fetches from the TUI API. Dead file, worth deleting.
- The `PR` marker is the mirror-image problem: registered as "run only in PR builds" and applied widely, but no `apimarkers` string says `not PR`, so those tests run in scheduled runs too.
- Worth checking: the api-tests action passes `-m "$api_markers"` on the command line while `pytest_ci.ini` addopts already has `-m "not upgrade and not resilience"`. pytest's `-m` is single-valued and the command line wins, so that exclusion is likely being dropped in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)