### PR TITLE
TT-18237: Notify the non-functional team of retention runs and tracks drift

### DIFF
--- a/.github/workflows/retention-plan.yml
+++ b/.github/workflows/retention-plan.yml
@@ -177,3 +177,24 @@ jobs:
                 }
               ]
             }
+
+      # The team copy posts on every run, so a silent month still
+      # confirms the automation ran
+      - name: Slack notice (team)
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.NONFUNC_SLACK_CHANNEL }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Retention plan run* — ${{ steps.diff.outputs.new_count }} newly eligible files, ${{ steps.diff.outputs.total_files }} total (${{ steps.diff.outputs.total_gib }} GiB), not_before *${{ steps.diff.outputs.not_before }}*.\n<https://github.com/TykTechnologies/artifact-retention-plans/commit/${{ steps.commit.outputs.sha }}|Committed plan> · <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Run>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/retention-restore.yml
+++ b/.github/workflows/retention-restore.yml
@@ -193,3 +193,25 @@ jobs:
                 }
               ]
             }
+
+      # Team copy: posts even when the run fails before the check step,
+      # so a restore that errored out is still noticed
+      - name: Slack notice (team)
+        if: always()
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.NONFUNC_SLACK_CHANNEL }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Retention restore run* — `${{ inputs.key }}` (${{ inputs.tier }} tier)\nState: ${{ steps.check.outputs.state || 'failed before the S3 check' }} · triggered by ${{ github.actor }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/tracks-freshness.yml
+++ b/.github/workflows/tracks-freshness.yml
@@ -1,0 +1,77 @@
+name: Tracks freshness
+
+# Compares the tracks config against the latest actual Gateway release
+# so a release that ships without a tracks update is noticed within a
+# week instead of at the next retention plan. Stale tracks are safe
+# (the retention window anchors too old, retaining more); tracks ahead
+# of reality are dangerous and flagged separately.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # 09:00 UTC every Monday
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout gromit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Compare tracks with the latest release
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          configured=$(yq '.tracks.gateway.current_feature' config/config.yaml)
+          latest_tag=$(gh api repos/TykTechnologies/tyk/releases/latest --jq '.tag_name')
+          latest=$(echo "${latest_tag#v}" | cut -d. -f1,2)
+          echo "configured=$configured" >> "$GITHUB_OUTPUT"
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+
+          state=ok
+          if [ "$configured" != "$latest" ]; then
+            newest=$(printf '%s\n%s\n' "$configured" "$latest" | sort -V | tail -1)
+            if [ "$newest" = "$configured" ]; then
+              # tracks claim a series that has not shipped: this moves
+              # the retention window forward of reality
+              state=ahead
+            else
+              state=stale
+            fi
+          fi
+          echo "state=$state" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Tracks freshness"
+            echo ""
+            echo "Configured current_feature: \`$configured\`"
+            echo "Latest Gateway release: \`$latest\` (\`$latest_tag\`)"
+            echo ""
+            echo "State: **$state**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Slack alert
+        if: steps.check.outputs.state != 'ok'
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.NONFUNC_SLACK_CHANNEL }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Tracks drift* — gromit's tracks say current_feature `${{ steps.check.outputs.configured }}` but the latest Gateway release is `${{ steps.check.outputs.latest }}`.\n${{ steps.check.outputs.state == 'ahead' && ':rotating_light: The config is AHEAD of reality: the retention window is anchored on an unreleased series. Fix config/config.yaml before the next retention plan runs.' || 'The config is stale: retention windows are anchored older than policy intends (safe, but the published policy lags). Update tracks in config/config.yaml as part of the release activities.' }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION


## Description
```
Change adds Slack notifications to the team channel: a new weekly Tracks
freshness workflow that alerts when the tracks config drifts from the latest
Gateway release, and team copies of the retention plan and restore notices
that post on every run, including failures. Commercial channel notices are unchanged.
```

<!-- Please include a summary of the changes and the motivation/context for this pull request. -->

**Jira Ticket:** [TT-18237](https://tyktech.atlassian.net/browse/TT-18237)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore / documentation / template sync

## Verification & Testing

<!-- Please describe the tests that you ran to verify your changes. -->

- [ ] I have run local unit tests (`go test ./policy/...`) and they passed.
- [ ] I have generated policy outputs locally (`go run . policy gen`) and verified the rendered files.
- [ ] I have verified the changes in target downstream repositories (e.g. `tyk`, `tyk-analytics`).

### Command(s) used for testing:

```bash
# Example: go run . policy gen /tmp/output --repo tyk --branch master
```

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings


[TT-18237]: https://tyktech.atlassian.net/browse/TT-18237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ